### PR TITLE
BAVL-137: Tweaked prisoner search query

### DIFF
--- a/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.test.ts
@@ -72,7 +72,7 @@ describe('Prisoner search handler', () => {
             {
               fieldId: 'lastName',
               href: '#lastName',
-              text: "You must search using either the prisoner's last name, prison number or PNC Number",
+              text: "You must search using either the prisoner's first name, last name, prison number or PNC Number",
             },
           ]),
         )
@@ -136,6 +136,13 @@ describe('Prisoner search handler', () => {
             },
           ]),
         )
+    })
+
+    it('should accept firstName on its own as the search criteria', () => {
+      return request(app)
+        .post(`/booking/court/create/${journeyId()}/prisoner-search`)
+        .send({ dateOfBirth: {}, firstName: 'John' })
+        .expect(() => expectNoErrorMessages())
     })
 
     it('should accept lastName on its own as the search criteria', () => {

--- a/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.ts
@@ -14,9 +14,12 @@ class Body {
   firstName: string
 
   @Expose()
-  @Validator((lastName, { prisonerNumber, pncNumber }) => lastName || prisonerNumber || pncNumber, {
-    message: "You must search using either the prisoner's last name, prison number or PNC Number",
-  })
+  @Validator(
+    (lastName, { firstName, prisonerNumber, pncNumber }) => firstName || lastName || prisonerNumber || pncNumber,
+    {
+      message: "You must search using either the prisoner's first name, last name, prison number or PNC Number",
+    },
+  )
   lastName: string
 
   @Expose()

--- a/server/services/prisonerService.test.ts
+++ b/server/services/prisonerService.test.ts
@@ -46,25 +46,26 @@ describe('Prisoner service', () => {
 
       expect(prisonerOffenderSearchApiClient.getByAttributes).toHaveBeenCalledWith(
         expect.objectContaining({
+          joinType: 'AND',
           queries: [
+            { matchers: [{ attribute: 'inOutStatus', condition: 'IS', searchTerm: 'IN', type: 'String' }] },
             {
-              matchers: [{ type: 'String', attribute: 'inOutStatus', condition: 'IS', searchTerm: 'IN' }],
-              joinType: 'AND',
+              joinType: 'OR',
               subQueries: [
                 {
                   joinType: 'AND',
                   matchers: [
-                    { type: 'String', attribute: 'firstName', condition: 'CONTAINS', searchTerm: 'John' },
-                    { type: 'String', attribute: 'lastName', condition: 'CONTAINS', searchTerm: 'Doe' },
-                    { type: 'Date', attribute: 'dateOfBirth', minValue: '1990-01-01', maxValue: '1990-01-01' },
-                    { type: 'String', attribute: 'prisonId', condition: 'IS', searchTerm: 'XYZ' },
+                    { attribute: 'firstName', condition: 'CONTAINS', searchTerm: 'John', type: 'String' },
+                    { attribute: 'lastName', condition: 'CONTAINS', searchTerm: 'Doe', type: 'String' },
+                    { attribute: 'dateOfBirth', maxValue: '1990-01-01', minValue: '1990-01-01', type: 'Date' },
+                    { attribute: 'prisonId', condition: 'IS', searchTerm: 'XYZ', type: 'String' },
                   ],
                 },
                 {
-                  joinType: 'OR',
+                  joinType: 'AND',
                   matchers: [
-                    { type: 'String', attribute: 'prisonerNumber', condition: 'IS', searchTerm: 'A12345' },
-                    { type: 'PNC', pncNumber: 'PNC123' },
+                    { attribute: 'prisonerNumber', condition: 'IS', searchTerm: 'A12345', type: 'String' },
+                    { pncNumber: 'PNC123', type: 'PNC' },
                   ],
                 },
               ],
@@ -91,15 +92,17 @@ describe('Prisoner service', () => {
 
       expect(prisonerOffenderSearchApiClient.getByAttributes).toHaveBeenCalledWith(
         expect.objectContaining({
+          joinType: 'AND',
           queries: [
+            { matchers: [{ attribute: 'inOutStatus', condition: 'IS', searchTerm: 'IN', type: 'String' }] },
             {
-              matchers: [{ type: 'String', attribute: 'inOutStatus', condition: 'IS', searchTerm: 'IN' }],
-              joinType: 'AND',
+              joinType: 'OR',
               subQueries: [
                 {
                   joinType: 'AND',
-                  matchers: [{ type: 'String', attribute: 'firstName', condition: 'CONTAINS', searchTerm: 'Jane' }],
+                  matchers: [{ attribute: 'firstName', condition: 'CONTAINS', searchTerm: 'Jane', type: 'String' }],
                 },
+                { joinType: 'AND', matchers: [] },
               ],
             },
           ],

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -39,15 +39,20 @@ export default class PrisonerService {
       createPncMatcher(criteria.pncNumber),
     ].filter(Boolean)
 
+    // For example:
+    // (inOutStatus = IN) AND ((firstName CONTAINS :firstName AND lastName CONTAINS :lastName) OR (prisonerNumber = :prisonerNumber AND pncNumber = :pncNumber))
     const searchQuery = {
+      joinType: 'AND',
       queries: [
         {
           matchers: [createStringMatcher('inOutStatus', 'IS', 'IN')],
-          joinType: 'AND',
+        },
+        {
+          joinType: 'OR',
           subQueries: [
             { joinType: 'AND', matchers },
-            { joinType: 'OR', matchers: secondaryMatchers },
-          ].filter(m => m.matchers.length > 0),
+            { joinType: 'AND', matchers: secondaryMatchers },
+          ],
         },
       ],
     }

--- a/server/views/pages/bookAVideoLink/prisonerSearch.njk
+++ b/server/views/pages/bookAVideoLink/prisonerSearch.njk
@@ -137,8 +137,6 @@
                     type: "submit"
                 }) }}
             </form>
-
-            <a href="#" class="govuk-link govuk-!-font-size-19">The prisoner is not listed</a>
         </div>
     </div>
 {% endblock %}

--- a/server/views/pages/bookAVideoLink/prisonerSearchResults.njk
+++ b/server/views/pages/bookAVideoLink/prisonerSearchResults.njk
@@ -91,6 +91,8 @@
                     items: paginationItems
                 }) }}
             {% endif %}
+
+            <a href="#" class="govuk-link govuk-!-font-size-19">The prisoner is not listed</a>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Old Query:

```
(inOutStatus = IN) AND (firstName CONTAINS :firstName AND lastName CONTAINS :lastName AND prisonerNumber = :prisonerNumber AND pncNumber = :pncNumber)
```

New Query:

```
(inOutStatus = IN) AND ((firstName CONTAINS :firstName AND lastName CONTAINS :lastName) OR (prisonerNumber = :prisonerNumber AND pncNumber = :pncNumber))
```

Also changed validation to allow firstName to be searched on its own