### PR TITLE
BAVL-226: Add form spinner component to form submissions

### DIFF
--- a/frontend/all.js
+++ b/frontend/all.js
@@ -1,6 +1,7 @@
 import { nodeListForEach } from './utils'
 import Card from './components/card/card'
 import DatePicker from './components/hmpps-date-picker/datePicker'
+import FormSpinner from './components/form-spinner/form-spinner'
 
 function initAll() {
   const $cards = document.querySelectorAll('.card--clickable')
@@ -11,6 +12,11 @@ function initAll() {
   const $datePickers = document.querySelectorAll('[data-module="hmpps-datepicker"]')
   nodeListForEach($datePickers, function ($datePicker) {
     new DatePicker($datePicker, {}).init()
+  })
+
+  var $spinnerForms = document.querySelectorAll('[data-module="form-spinner"]')
+  nodeListForEach($spinnerForms, function ($spinnerForm) {
+    new FormSpinner($spinnerForm)
   })
 }
 

--- a/frontend/components/_all.scss
+++ b/frontend/components/_all.scss
@@ -1,5 +1,6 @@
-@import './card/card';
-@import './header-bar/header-bar';
+@import 'card/card';
+@import 'header-bar/header-bar';
 @import 'hmpps-date-picker/date-picker';
 @import 'hmpps-time-picker/time-picker';
 @import 'tags/tags';
+@import 'form-spinner/form-spinner';

--- a/frontend/components/form-spinner/_form-spinner.scss
+++ b/frontend/components/form-spinner/_form-spinner.scss
@@ -1,0 +1,109 @@
+@use "sass:math";
+
+.form-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.3);
+  color: govuk-colour("white");
+  @include govuk-font($size: 24, $line-height: 1, $weight: bold);
+
+  &__notification-box {
+    border-radius: 10px;
+    background: rgba(0,0,0,0.8);
+    padding: govuk-spacing(4);
+  }
+
+  &__spinner {
+    margin-top: govuk-spacing(4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+// Source: https://loading.io/css/
+$size: 50px;
+$scale: $size / 80px;
+.lds-spinner {
+  display: inline-block;
+  position: relative;
+  width: $size;
+  height: $size;
+}
+.lds-spinner div {
+  transform-origin: (40px * $scale) (40px * $scale);
+  animation: lds-spinner 1.2s linear infinite;
+}
+.lds-spinner div:after {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 3px * $scale;
+  left: 37px * $scale;
+  width: 6px * $scale;
+  height: 18px * $scale;
+  border-radius: 20%;
+  background: #fff;
+}
+.lds-spinner div:nth-child(1) {
+  transform: rotate(0deg);
+  animation-delay: -1.1s;
+}
+.lds-spinner div:nth-child(2) {
+  transform: rotate(30deg);
+  animation-delay: -1s;
+}
+.lds-spinner div:nth-child(3) {
+  transform: rotate(60deg);
+  animation-delay: -0.9s;
+}
+.lds-spinner div:nth-child(4) {
+  transform: rotate(90deg);
+  animation-delay: -0.8s;
+}
+.lds-spinner div:nth-child(5) {
+  transform: rotate(120deg);
+  animation-delay: -0.7s;
+}
+.lds-spinner div:nth-child(6) {
+  transform: rotate(150deg);
+  animation-delay: -0.6s;
+}
+.lds-spinner div:nth-child(7) {
+  transform: rotate(180deg);
+  animation-delay: -0.5s;
+}
+.lds-spinner div:nth-child(8) {
+  transform: rotate(210deg);
+  animation-delay: -0.4s;
+}
+.lds-spinner div:nth-child(9) {
+  transform: rotate(240deg);
+  animation-delay: -0.3s;
+}
+.lds-spinner div:nth-child(10) {
+  transform: rotate(270deg);
+  animation-delay: -0.2s;
+}
+.lds-spinner div:nth-child(11) {
+  transform: rotate(300deg);
+  animation-delay: -0.1s;
+}
+.lds-spinner div:nth-child(12) {
+  transform: rotate(330deg);
+  animation-delay: 0s;
+}
+@keyframes lds-spinner {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/frontend/components/form-spinner/form-spinner.js
+++ b/frontend/components/form-spinner/form-spinner.js
@@ -1,0 +1,32 @@
+import { nodeListForEach } from '../../utils'
+
+function FormSpinner(container) {
+  this.container = container
+
+  this.spinnerSvg =
+    '<div class="lds-spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>'
+
+  this.container.addEventListener('submit', () => {
+    const formSpinnerTemplate = document.createElement('template')
+    formSpinnerTemplate.innerHTML = `
+      <div class="form-spinner">
+        <div class="form-spinner__notification-box" role="alert">
+          ${this.container.dataset.loadingText ?? 'Loading'}
+          <div class="form-spinner__spinner">
+            ${this.spinnerSvg}
+          </div>
+        </div>
+      </div>
+    `.trim()
+
+    setTimeout(() => document.querySelector('body').appendChild(formSpinnerTemplate.content.firstChild), 1000)
+
+    const buttons = this.container.querySelectorAll('[data-module="govuk-button"]')
+    nodeListForEach(buttons, function (button) {
+      button.setAttribute('disabled', 'disabled')
+      button.setAttribute('aria-disabled', 'true')
+    })
+  })
+}
+
+export default FormSpinner

--- a/server/views/pages/bookAVideoLink/checkBooking.njk
+++ b/server/views/pages/bookAVideoLink/checkBooking.njk
@@ -155,7 +155,7 @@
                 ]
             }) }}
 
-            <form method="POST" class="govuk-!-margin-top-6">
+            <form method="POST" class="govuk-!-margin-top-6" data-module="form-spinner" data-loading-text="{{ "Booking video link" if mode == 'create' else "Updating booking" }}">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ govukCharacterCount({
@@ -173,7 +173,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Book video link" if mode == 'create' else 'Update video link',
+                    text: "Book video link" if mode == 'create' else 'Update booking',
+                    preventDoubleClick: true,
                     type: 'submit'
                 }) }}
             </form>

--- a/server/views/pages/bookAVideoLink/comments.njk
+++ b/server/views/pages/bookAVideoLink/comments.njk
@@ -14,7 +14,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <form method="POST" action='check-booking'>
+            <form method="POST" action='check-booking' data-module="form-spinner" data-loading-text="Updating comments">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ govukCharacterCount({
@@ -26,7 +26,11 @@
                     value: session.journey.bookAVideoLink.comments
                 }) }}
 
-                {{ govukButton({ text: "Continue", type: "submit" }) }}
+                {{ govukButton({
+                    text: "Continue",
+                    preventDoubleClick: true,
+                    type: "submit"
+                }) }}
             </form>
 
             <a href="/{{ session.req.params.type }}/view-booking/{{ session.journey.bookAVideoLink.bookingId }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" data-qa='cancel-link'>Cancel</a>

--- a/server/views/pages/bookAVideoLink/confirmCancel.njk
+++ b/server/views/pages/bookAVideoLink/confirmCancel.njk
@@ -17,13 +17,14 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <form method='POST'>
+            <form method='POST' data-module="form-spinner" data-loading-text="Cancelling booking">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 <div class="govuk-button-group">
                     {{ govukButton({
                         text: "Yes, cancel the booking",
                         classes: "govuk-button--warning",
+                        preventDoubleClick: true,
                         type: "submit"
                     }) }}
 

--- a/server/views/pages/bookAVideoLink/prisonerSearch.njk
+++ b/server/views/pages/bookAVideoLink/prisonerSearch.njk
@@ -22,7 +22,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <form method='POST'>
+            <form method='POST' data-module="form-spinner" data-loading-text="Searching prisoners">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ govukInput({
@@ -133,6 +133,7 @@
 
                 {{ govukButton({
                     html: "Search<span class='govuk-visually-hidden'> and display the results below</span>",
+                    preventDoubleClick: true,
                     isStartButton: true,
                     type: "submit"
                 }) }}

--- a/server/views/pages/userPreferences/list.njk
+++ b/server/views/pages/userPreferences/list.njk
@@ -29,7 +29,7 @@
                 <h2 class="govuk-heading-m">Probation teams by A-Z</h2>
             {% endif %}
 
-            <form method='POST'>
+            <form method='POST' data-module="form-spinner">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {% set sections = [] %}
@@ -68,7 +68,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Confirm"
+                        text: "Confirm",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>


### PR DESCRIPTION
Prevents double form submissions to pages which make POST requests to BAVL API or which perform large queries (e.g. prisoner search) 

<img width="1512" alt="Screenshot 2024-06-26 at 09 39 42" src="https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/assets/30229564/e502977d-8e2a-43cd-9db0-62b1436a50bf">
<img width="1512" alt="Screenshot 2024-06-26 at 09 42 46" src="https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/assets/30229564/96512b68-32c6-445f-92d4-6e6ee1918945">
<img width="1512" alt="Screenshot 2024-06-26 at 09 43 28" src="https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/assets/30229564/4b64ff4e-8957-4977-844a-903c40cae0d4">
<img width="1512" alt="Screenshot 2024-06-26 at 09 44 15" src="https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/assets/30229564/18d33078-24e7-427e-b24b-bfd9835e4038">
<img width="1512" alt="Screenshot 2024-06-26 at 09 44 44" src="https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/assets/30229564/24b3234e-0797-4805-8936-d81c6ae8654c">
