### PR TITLE
BAVL-317 prevent changing of court and probation team, attributes are not updatable once created.

### DIFF
--- a/server/routes/journeys/bookAVideoLink/handlers/newBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/newBookingHandler.test.ts
@@ -186,6 +186,7 @@ describe('New Booking handler', () => {
           const heading = getPageHeader($)
 
           expect(heading).toEqual('Change video link booking')
+          expect(existsByLabel($, 'Which court is the hearing for?')).toBe(false)
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.BOOKING_DETAILS_PAGE, {
             who: user.username,
             correlationId: expect.any(String),

--- a/server/views/pages/bookAVideoLink/newBooking.njk
+++ b/server/views/pages/bookAVideoLink/newBooking.njk
@@ -60,17 +60,35 @@
                         } if agencies.length == 1 and session.req.params.type == BavlJourneyType.COURT,
                         {
                             key: {
+                                text: "Court"
+                            },
+                            value: {
+                                text: (agencies | find('code', session.journey.bookAVideoLink.agencyCode)).description
+                            }
+                        } if mode == 'amend' and agencies.length > 1 and session.req.params.type == BavlJourneyType.COURT,
+                        {
+                            key: {
                                 text: "Probation Team"
                             },
                             value: {
                                 text: agencies[0].description
                             }
-                        } if agencies.length == 1 and session.req.params.type == BavlJourneyType.PROBATION
+                        } if agencies.length == 1 and session.req.params.type == BavlJourneyType.PROBATION,
+                        {
+                            key: {
+                                text: "Probation Team"
+                            },
+                            value: {
+                                text: (agencies | find('code', session.journey.bookAVideoLink.agencyCode)).description
+                            }
+                        } if mode == 'amend' and agencies.length > 1 and session.req.params.type == BavlJourneyType.PROBATION
                     ]
                 }) }}
 
                 {% if agencies.length === 1 %}
                     <input type="hidden" name="agencyCode" value="{{ agencies[0].code }}" />
+                {% elseif mode === 'amend' %}
+                    <input type="hidden" name="agencyCode" value="{{ session.journey.bookAVideoLink.agencyCode }}" />
                 {% else %}
                     
                     {% set items = [{ text: "Select court" if session.req.params.type == BavlJourneyType.COURT else "Select probation team", value: "" }] %}


### PR DESCRIPTION
This is an interim change in preparation for the API have this restriction added (i.e. the ability to change the court or probation team ).

**Probation:**

![change-probation-bvls](https://github.com/user-attachments/assets/2ba33cfe-b226-45b3-af7d-e6a5502b30c2)

**Court:**

![change-court-bvls](https://github.com/user-attachments/assets/7936fcea-02d5-4838-8c6f-a849eac7102e)
