### PR TITLE
Test redirecting to old BVLS within the ingress layer

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,10 +2,13 @@
 # Per environment values which override defaults in hmpps-book-a-video-link-ui/values.yaml
 
 generic-service:
-  replicaCount: 2
+  replicaCount: 0
 
   ingress:
     host: book-a-video-link-dev.prison.service.justice.gov.uk
+    annotations:
+      nginx.ingress.kubernetes.io/server-snippet: |
+        return 301 https://book-video-link-dev.prison.service.justice.gov.uk;
 
   env:
     INGRESS_URL: "https://book-a-video-link-dev.prison.service.justice.gov.uk"


### PR DESCRIPTION
Testing redirecting to old-bvls within the ingress layer and scaling down pods to 0. This will be the same the other way around if we choose to do so for the rollout. I will revert this after testing it