### PR TITLE
BAVL-393 small fix to the validation message when a probation meeting type is not entered on creation of a booking.

### DIFF
--- a/server/routes/journeys/bookAVideoLink/handlers/newBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/newBookingHandler.test.ts
@@ -316,7 +316,7 @@ describe('New Booking handler', () => {
             {
               fieldId: 'hearingTypeCode',
               href: '#hearingTypeCode',
-              text: 'Select a hearing type',
+              text: 'Select a meeting type',
             },
             {
               fieldId: 'date',

--- a/server/routes/journeys/bookAVideoLink/handlers/newBookingHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/newBookingHandler.ts
@@ -31,7 +31,10 @@ class Body {
   agencyCode: string
 
   @Expose()
-  @IsNotEmpty({ message: `Select a hearing type` })
+  @IsNotEmpty({
+    message: args =>
+      `Select a ${(args.object as { type: string }).type === BavlJourneyType.COURT ? 'hearing type' : 'meeting type'}`,
+  })
   hearingTypeCode: string
 
   @Expose()


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/579a6c69-a293-4269-9b26-6ae9dc13fc3f)

After:

![image](https://github.com/user-attachments/assets/547afb86-0893-4023-a41d-dc2c76eef9cf)
