### PR TITLE
Fix issue where an non-implemented HTTP method may not get handled correctly

### DIFF
--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,9 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import { NotFound } from 'http-errors'
 
 export default function asyncMiddleware(fn: RequestHandler) {
   return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
+    if (fn) Promise.resolve(fn(req, res, next)).catch(next)
+    else next(new NotFound())
   }
 }


### PR DESCRIPTION
Fixes a small issue where I could force by browser to make a POST request to a URL which doesnt have a corresponding handler which would produce the following error. It now throws a 404 as expected.

![screencapture-localhost-3000-2024-11-25-11_25_53](https://github.com/user-attachments/assets/db46bcc7-827d-4981-a269-65dd644a66ed)
