### PR TITLE
BAVL-538 replacing use of toISOString as this was converting dates to UTC which meant incorrect data was being passed to search depending on date chosen.

### DIFF
--- a/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.test.ts
@@ -173,7 +173,7 @@ describe('Prisoner search handler', () => {
         .then(() =>
           expectJourneySession(app, 'bookAVideoLink', {
             search: {
-              dateOfBirth: '1990-06-02T00:00:00.000Z',
+              dateOfBirth: '1990-06-02',
               firstName: 'Bob',
               lastName: 'Smith',
               pncNumber: '2001/23456A',

--- a/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/handlers/prisonerSearchHandler.ts
@@ -6,7 +6,7 @@ import { startOfToday } from 'date-fns'
 import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../interfaces/pageHandler'
 import Validator from '../../../validators/validator'
-import { simpleDateToDate } from '../../../../utils/utils'
+import { simpleDateToDate, toDateString } from '../../../../utils/utils'
 import IsValidDate from '../../../validators/isValidDate'
 import PrisonService from '../../../../services/prisonService'
 
@@ -65,7 +65,7 @@ export default class PrisonerSearchHandler implements PageHandler {
       search: {
         firstName: body.firstName,
         lastName: body.lastName,
-        dateOfBirth: body.dateOfBirth?.toISOString(),
+        dateOfBirth: body.dateOfBirth ? toDateString(body.dateOfBirth) : null,
         prison: body.prison,
         prisonerNumber: body.prisonerNumber,
         pncNumber: body.pncNumber,

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -9,6 +9,7 @@ import {
   parseDatePickerDate,
   simpleDateToDate,
   simpleTimeToDate,
+  toDateString,
 } from './utils'
 import { VideoLinkBooking } from '../@types/bookAVideoLinkApi/types'
 
@@ -192,5 +193,12 @@ describe('extractPrisonAppointmentsFromBooking', () => {
       mainAppointment: mainHearing,
       postAppointment: postHearing,
     })
+  })
+})
+
+describe('toDateString', () => {
+  it('converts a date to a string', () => {
+    expect(toDateString(new Date(2022, 2, 31))).toEqual('2022-03-31')
+    expect(toDateString(new Date(2022, 9, 20))).toEqual('2022-10-20')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -78,3 +78,5 @@ export const extractPrisonAppointmentsFromBooking = (booking: VideoLinkBooking) 
     postAppointment: getAppointment('VLB_COURT_POST'),
   }
 }
+
+export const toDateString = (date: Date) => format(date, 'yyyy-MM-dd')


### PR DESCRIPTION
Date conversion in the search was converting dates to UTC so depending on the date chosen, the dates being passed to search were not actually what was intended resulting in nothing found in some cases.