### PR TITLE
BAV-600: Avoid wrapping text in radio labels

### DIFF
--- a/frontend/utilities/_all.scss
+++ b/frontend/utilities/_all.scss
@@ -1,1 +1,2 @@
 @import "./horizontal-form";
+@import "./radio-nowrap";

--- a/frontend/utilities/_radio-nowrap.scss
+++ b/frontend/utilities/_radio-nowrap.scss
@@ -1,0 +1,3 @@
+.radio-nowrap {
+  white-space: nowrap;
+}

--- a/server/views/pages/admin/viewPrisonRoom.njk
+++ b/server/views/pages/admin/viewPrisonRoom.njk
@@ -36,7 +36,7 @@
                 </div>
 
                 {{ govukRadios({
-                     classes: "govuk-radios--inline govuk-radios--small",
+                     classes: "govuk-radios--inline govuk-radios--small radio-nowrap",
                      idPrefix: "roomStatus",
                      name: "roomStatus",
                      errorMessage: validationErrors | findError('roomStatus'),


### PR DESCRIPTION
Minor change to no-wrap radio labels 