### PR TITLE
BAVL-609: Change time slot in session if selecting an alernative suggestion

### DIFF
--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingAvailabilityHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingAvailabilityHandler.test.ts
@@ -99,7 +99,7 @@ describe('Booking availability handler', () => {
           })
 
           expect(probationBookingService.getAvailableLocations).toHaveBeenCalled()
-          expect(radios).toEqual(['10:00///12:00///VIDEO_1', '11:00///13:00///VIDEO_2'])
+          expect(radios).toEqual(['10:00///12:00///VIDEO_1///AM', '11:00///13:00///VIDEO_2///AM'])
         })
     })
 
@@ -133,7 +133,7 @@ describe('Booking availability handler', () => {
 
           expect(heading).toEqual('No bookings available for your selected time periods')
           expect(probationBookingService.getAvailableLocations).toHaveBeenCalled()
-          expect(radios).toEqual(['13:00///14:00///VIDEO_1', '15:00///16:00///VIDEO_2'])
+          expect(radios).toEqual(['13:00///14:00///VIDEO_1///PM', '15:00///16:00///VIDEO_2///PM'])
         })
     })
 
@@ -157,7 +157,7 @@ describe('Booking availability handler', () => {
 
   describe('POST', () => {
     const validForm = {
-      option: '11:00///12:00///VIDEO_2',
+      option: '15:00///16:00///VIDEO_2///PM',
     }
 
     it('should validate an empty form', () => {
@@ -186,9 +186,10 @@ describe('Booking availability handler', () => {
         .then(() =>
           expectJourneySession(app, 'bookAProbationMeeting', {
             ...bookAProbationMeetingSession,
-            startTime: '1970-01-01T11:00:00.000Z',
-            endTime: '1970-01-01T12:00:00.000Z',
+            startTime: '1970-01-01T15:00:00.000Z',
+            endTime: '1970-01-01T16:00:00.000Z',
             locationCode: 'VIDEO_2',
+            timePeriods: ['PM'],
           }),
         )
     })

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingAvailabilityHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingAvailabilityHandler.ts
@@ -24,6 +24,10 @@ class Body {
   @Expose()
   @Transform(({ obj }) => obj.option && obj.option.split('///')[2])
   dpsLocationKey: string
+
+  @Expose()
+  @Transform(({ obj }) => obj.option && obj.option.split('///')[3])
+  timeSlot: string
 }
 
 export default class BookingAvailabilityHandler implements PageHandler {
@@ -46,13 +50,14 @@ export default class BookingAvailabilityHandler implements PageHandler {
   }
 
   public POST = async (req: Request, res: Response) => {
-    const { startTime, endTime, dpsLocationKey } = req.body
+    const { startTime, endTime, dpsLocationKey, timeSlot } = req.body
 
     req.session.journey.bookAProbationMeeting = {
       ...req.session.journey.bookAProbationMeeting,
       startTime: startTime.toISOString(),
       endTime: endTime.toISOString(),
       locationCode: dpsLocationKey,
+      timePeriods: [timeSlot],
     }
 
     return res.redirect('check-booking')

--- a/server/views/pages/bookAVideoLink/probation/availability.njk
+++ b/server/views/pages/bookAVideoLink/probation/availability.njk
@@ -97,7 +97,7 @@
 
                         {% set items = [] %}
                         {% for option in options %}
-                            {% set value = option.startTime + '///' + option.endTime + '///' + option.dpsLocationKey %}
+                            {% set value = option.startTime + '///' + option.endTime + '///' + option.dpsLocationKey + '///' + option.timeSlot %}
                             {% set items = (items.push({
                                 value: value,
                                 html: '


### PR DESCRIPTION
The check answers screen was still displaying "Morning" as the time period even when you had chosen an alternative suggestion which was in the afternoon