### PR TITLE
BAVL-706: Updating the court confirmation screen with design/content and PVL links

### DIFF
--- a/server/routes/journeys/bookAVideoLink/court/handlers/confirmationHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/confirmationHandler.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 })
 
 describe('GET', () => {
-  it('should render the correct view page', () => {
+  it('should render the correct view page', async () => {
     videoLinkService.getVideoLinkBookingById.mockResolvedValue(getCourtBooking('AA1234A'))
     prisonerService.getPrisonerByPrisonerNumber.mockResolvedValue({
       firstName: 'Joe',
@@ -49,7 +49,7 @@ describe('GET', () => {
     prisonService.getPrisonByCode.mockResolvedValue({ code: 'MDI', name: 'Moorland (HMP)' } as Prison)
     prisonService.getAppointmentLocations.mockResolvedValue([{ key: 'KEY', description: 'description' }] as Location[])
 
-    return request(app)
+    await request(app)
       .get(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking/confirmation/1`)
       .expect('Content-Type', /html/)
       .expect(res => {
@@ -71,10 +71,10 @@ describe('GET', () => {
         expect(getValueByKey($, 'Name')).toEqual('Joe Bloggs (AA1234A)')
         expect(getValueByKey($, 'Prison')).toEqual('Moorland (HMP)')
       })
-      .then(() => expectJourneySession(app, 'bookACourtHearing', null))
+    return expectJourneySession(app, 'bookACourtHearing', null)
   })
 
-  it('should render the correct page in amend mode', () => {
+  it('should render the correct page in amend mode', async () => {
     videoLinkService.bookingIsAmendable.mockReturnValue(true)
     videoLinkService.getVideoLinkBookingById.mockResolvedValue(getCourtBooking('AA1234A'))
     prisonerService.getPrisonerByPrisonerNumber.mockResolvedValue({
@@ -85,7 +85,7 @@ describe('GET', () => {
     } as Prisoner)
     prisonService.getAppointmentLocations.mockResolvedValue([{ key: 'KEY', description: 'description' }] as Location[])
 
-    return request(app)
+    await request(app)
       .get(`/court/booking/amend/1/${journeyId()}/video-link-booking/confirmation`)
       .expect('Content-Type', /html/)
       .expect(res => {
@@ -103,7 +103,7 @@ describe('GET', () => {
 
         expect(heading).toEqual('The video link booking has been updated')
       })
-      .then(() => expectJourneySession(app, 'bookACourtHearing', null))
+    return expectJourneySession(app, 'bookACourtHearing', null)
   })
 })
 

--- a/server/views/pages/bookAVideoLink/court/confirmation.njk
+++ b/server/views/pages/bookAVideoLink/court/confirmation.njk
@@ -52,14 +52,6 @@
                     },
                     {
                         key: {
-                            text: "Prison room"
-                        },
-                        value: {
-                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_MAIN')).prisonLocKey)).description
-                        }
-                    },
-                    {
-                        key: {
                             text: "Date"
                         },
                         value: {
@@ -68,44 +60,76 @@
                     },
                     {
                         key: {
-                            text: "Hearing start time"
+                            text: "Pre-court hearing time"
                         },
                         value: {
-                            text: (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_MAIN')).startTime
-                        }
-                    },
-                    {
-                        key: {
-                            text: "Hearing end time"
-                        },
-                        value: {
-                            text: (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_MAIN')).endTime
-                        }
-                    },
-                    {
-                        key: {
-                            text: "Pre-court hearing"
-                        },
-                        value: {
-                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).prisonLocKey)).description + " - " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).startTime + " to " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).endTime
+                            text: (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).startTime + " to " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).endTime
                         }
                     } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE'),
                     {
                         key: {
-                            text: "Post-court hearing"
+                            text: "Pre-court hearing room"
                         },
                         value: {
-                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).prisonLocKey)).description + " - " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).startTime + " to " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).endTime
+                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).prisonLocKey)).description
                         }
-                    } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST'),
+                    } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE'),
                     {
                         key: {
-                            text: "Court hearing link"
+                            text: "Pre-court hearing link (PVL)"
+                        },
+                        value: {
+                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE')).prisonLocKey)).extraAttributes.prisonVideoUrl or "Not yet known"
+                        }
+                    } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_PRE'),
+                    {
+                        key: {
+                            text: "Court hearing time"
+                        },
+                        value: {
+                            text: (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_MAIN')).startTime + " to " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_MAIN')).endTime
+                        }
+                    },
+                    {
+                        key: {
+                            text: "Court hearing room"
+                        },
+                        value: {
+                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_MAIN')).prisonLocKey)).description
+                        }
+                    },
+                    {
+                        key: {
+                            text: "Court hearing link (CVP)"
                         },
                         value: {
                             text: booking.videoLinkUrl or "Not yet known"
                         }
-                    }
+                    },
+                    {
+                        key: {
+                            text: "Post-court hearing time"
+                        },
+                        value: {
+                            text: (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).startTime + " to " + (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).endTime
+                        }
+                    } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST'),
+                    {
+                        key: {
+                            text: "Post-court hearing room"
+                        },
+                        value: {
+                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).prisonLocKey)).description
+                        }
+                    } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST'),
+                    {
+                        key: {
+                            text: "Post-court hearing link (PVL)"
+                        },
+                        value: {
+                            text: (rooms | find('key', (booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')).prisonLocKey)).extraAttributes.prisonVideoUrl or "Not yet entered"
+                        }
+                    } if booking.prisonAppointments | find('appointmentType', 'VLB_COURT_POST')
                 ]
             }) }}
 


### PR DESCRIPTION
Labels and content like the check-booking form, including PVL links for pre/post hearings.

![image](https://github.com/user-attachments/assets/c74eae00-0070-4b7d-b2fa-a7b57b59be4e)
