### PR TITLE
BAVL-792 removing prisoner names from the page title but still including in the headers.

### DIFF
--- a/server/views/pages/bookAVideoLink/court/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/court/bookingDetails.njk
@@ -10,12 +10,13 @@
 
 {% set mode = session.req.params.mode %}
 {% set prisonerName = ((prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase) %}
-{% set pageTitle = "Change " + prisonerName + "'s video link booking" if mode == 'amend' else "Select a date and time for " + prisonerName +"'s court hearings" %}
+{% set pageTitle = "Change video link booking" if mode == 'amend' else "Select a date and time for these court hearings" %}
+{% set pageHeading = "Change " + prisonerName + "'s video link booking" if mode == 'amend' else "Select a date and time for " + prisonerName +"'s court hearings" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         </div>
     </div>
 

--- a/server/views/pages/bookAVideoLink/court/confirmCancel.njk
+++ b/server/views/pages/bookAVideoLink/court/confirmCancel.njk
@@ -3,12 +3,13 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Are you sure you want to cancel " + ((session.journey.bookACourtHearing.prisoner.firstName + " " + session.journey.bookACourtHearing.prisoner.lastName) | convertToTitleCase) + "'s booking?" %}
+{% set pageTitle = "Are you sure you want to cancel this booking?" %}
+{% set pageHeading = "Are you sure you want to cancel " + ((session.journey.bookACourtHearing.prisoner.firstName + " " + session.journey.bookACourtHearing.prisoner.lastName) | convertToTitleCase) + "'s booking?" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
             {{ govukInsetText({
                 html: "The cancellation of a booking cannot be reversed."
             }) }}

--- a/server/views/pages/bookAVideoLink/court/selectRooms.njk
+++ b/server/views/pages/bookAVideoLink/court/selectRooms.njk
@@ -10,12 +10,13 @@
 
 {% set mode = session.req.params.mode %}
 {% set prisonerName = ((session.journey.bookACourtHearing.prisoner.firstName + " " + session.journey.bookACourtHearing.prisoner.lastName) | convertToTitleCase) %}
-{% set pageTitle = "Select rooms for " + prisonerName + "'s court hearings" %}
+{% set pageTitle = "Select rooms for court hearings" %}
+{% set pageHeading = "Select rooms for " + prisonerName + "'s court hearings" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         </div>
     </div>
 

--- a/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
@@ -9,12 +9,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set mode = session.req.params.mode %}
-{% set pageTitle = ("Change" if mode == 'amend' else "Enter") + ' probation video link booking details for ' + ((prisoner.firstName + " " + prisoner.lastName) | convertToTitleCase) %}
+{% set pageTitle = ("Change" if mode == 'amend' else "Enter") + ' probation video link booking details' %}
+{% set pageHeading = ("Change" if mode == 'amend' else "Enter") + ' probation video link booking details for ' + ((prisoner.firstName + " " + prisoner.lastName) | convertToTitleCase) %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         </div>
     </div>
 

--- a/server/views/pages/bookAVideoLink/probation/confirmCancel.njk
+++ b/server/views/pages/bookAVideoLink/probation/confirmCancel.njk
@@ -3,12 +3,13 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Are you sure you want to cancel " + ((session.journey.bookAProbationMeeting.prisoner.firstName + " " + session.journey.bookAProbationMeeting.prisoner.lastName) | convertToTitleCase) + "'s booking?" %}
+{% set pageTitle = "Are you sure you want to cancel this booking?" %}
+{% set pageHeading = "Are you sure you want to cancel " + ((session.journey.bookAProbationMeeting.prisoner.firstName + " " + session.journey.bookAProbationMeeting.prisoner.lastName) | convertToTitleCase) + "'s booking?" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
             {{ govukInsetText({
                 html: "The cancellation of a booking cannot be reversed."
             }) }}

--- a/server/views/pages/viewBooking/viewBooking.njk
+++ b/server/views/pages/viewBooking/viewBooking.njk
@@ -4,7 +4,8 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = ((prisoner.firstName + " " + prisoner.lastName) | convertToTitleCase) + "’s video link details" %}
+{% set pageTitle = "Video link details" %}
+{% set pageHeading = ((prisoner.firstName + " " + prisoner.lastName) | convertToTitleCase) + "’s video link details" %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -18,7 +19,7 @@
                 {{ govukNotificationBanner({ html: html, attributes: {"data-qa": 'cancelled-banner'} }) }}
             {% endif %}
 
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
         </div>
     </div>
 


### PR DESCRIPTION
This change removes the prisoner name from the page title(s) but still includes in the header(s).

We have made this change to ensure we do not include the name in any page analytics further down the line.