### PR TITLE
Task/bavl 809 content change available probation bookings

### DIFF
--- a/server/routes/testutils/cheerio.ts
+++ b/server/routes/testutils/cheerio.ts
@@ -4,7 +4,9 @@ export const getPageHeader = ($: Root) => $('h1').text().trim()
 export const getByDataQa = ($: Root, dataQa: string) => $(`[data-qa=${dataQa}]`)
 export const existsByDataQa = ($: Root, dataQa: string) => getByDataQa($, dataQa).length > 0
 export const getByName = ($: Root, name: string) => $(`[name=${name}]`)
+export const getTextById = ($: Root, id: string) => $(`[id=${id}]`).text().trim()
 export const existsByName = ($: Root, name: string) => getByName($, name).length > 0
+export const getPageAlert = ($: Root) => $('div.moj-alert__content').text().trim()
 
 export const getByLabel = ($: Root, label: string) => {
   const lbl = $(`label:contains("${label}")`)

--- a/server/views/pages/bookAVideoLink/probation/availability.njk
+++ b/server/views/pages/bookAVideoLink/probation/availability.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set availableBookings = requestedSlots.length > 0 %}
 {% set otherBookingsAvailableOnly = (not availableBookings) and otherSlots.length > 0 %}
@@ -35,7 +36,7 @@
                     variant: "information",
                     title: "No bookings available",
                     dismissible: false,
-                    text: 'There are no bookings available on the date you selected. You will need to change the date.'
+                    text: 'There are no more bookings available for probation meetings on the date you selected. You will need to change the date.'
                 }) }}
             </div>
         </div>
@@ -82,6 +83,12 @@
                 href: '../video-link-booking' + ('#date' if noBookings else "#timePeriods"),
                 classes: 'govuk-button--blue'
             }) }}
+
+            {% if availableBookings or otherBookingsAvailableOnly %}
+              {{ govukInsetText({
+                text: "Some rooms and times are allocated to court users only. The bookings shown below are the only times available for probation meetings."
+              }) }}
+            {% endif %}
         </div>
     </div>
 

--- a/server/views/pages/bookAVideoLink/probation/availability.njk
+++ b/server/views/pages/bookAVideoLink/probation/availability.njk
@@ -86,6 +86,7 @@
 
             {% if availableBookings or otherBookingsAvailableOnly %}
               {{ govukInsetText({
+                id: "probation-rooms-available",
                 text: "Some rooms and times are allocated to court users only. The bookings shown below are the only times available for probation meetings."
               }) }}
             {% endif %}


### PR DESCRIPTION
Text has been change inline with the attached images.  Refer to the Jira ticket to check.

![available-bookings](https://github.com/user-attachments/assets/5c3446fa-5ce2-4163-bfe5-e2628174af76)

![no-bookings-for-selected-period](https://github.com/user-attachments/assets/a0d4627b-0a3c-4200-b835-501d5648d18c)

![no-bookings-available](https://github.com/user-attachments/assets/a69d45b8-d02b-466d-bf08-5064b77b836e)
