### PR TITLE
BAVL-725 adding the appointment type column for court CSV downloads.

### DIFF
--- a/server/routes/journeys/viewBooking/handlers/downloadCsvHandler.test.ts
+++ b/server/routes/journeys/viewBooking/handlers/downloadCsvHandler.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
 describe('GET', () => {
   it('should download court csv for today', () => {
     const expectedCsv =
-      'Appointment Start Time,Appointment End Time,Prison,Prisoner Name,Prisoner Number,Hearing Type,Court Hearing Link,Room Hearing Link\n12:45,13:15,HMP Moorland,John Doe,A1234AA,Appeal hearing,https://court.link.url,'
+      'Appointment Start Time,Appointment End Time,Prison,Prisoner Name,Prisoner Number,Appointment Type,Hearing Type,Court Hearing Link,Room Hearing Link\n12:45,13:15,HMP Moorland,John Doe,A1234AA,Court hearing,Appeal hearing,https://court.link.url,'
 
     videoLinkService.getVideoLinkSchedule.mockResolvedValue([getCourtBooking()])
 

--- a/server/routes/journeys/viewBooking/handlers/downloadCsvHandler.ts
+++ b/server/routes/journeys/viewBooking/handlers/downloadCsvHandler.ts
@@ -51,10 +51,23 @@ export default class DownloadCsvHandler implements PageHandler {
       Prison: a.prisonName,
       'Prisoner Name': convertToTitleCase(`${a.prisonerName}`),
       'Prisoner Number': a.prisonerNumber,
+      'Appointment Type': this.courtAppointmentType(a.appointmentType),
       'Hearing Type': a.hearingTypeDescription,
       'Court Hearing Link': a.appointmentType === 'VLB_COURT_MAIN' && a.videoUrl ? a.videoUrl : '',
       'Room Hearing Link': a.appointmentType !== 'VLB_COURT_MAIN' && a.videoUrl ? a.videoUrl : '',
     }))
+  }
+
+  private courtAppointmentType(appointmentType: string) {
+    if (appointmentType === 'VLB_COURT_MAIN') {
+      return 'Court hearing'
+    }
+
+    if (appointmentType === 'VLB_COURT_PRE') {
+      return 'Pre-hearing'
+    }
+
+    return 'Post-hearing'
   }
 
   private probationTeam = (items: (ScheduleItem & { prisonerName: string; prisonLocationDescription: string })[]) => {


### PR DESCRIPTION
This changes adds another column for the court CSV extract to include the appointment type i.e. Pre-hearing, Court hearing and Post-hearing.