### PR TITLE
BAVL-851 resolving CVE 401 for transient dependendency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14703,10 +14703,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "wiremock": "^3.12.1"
   },
   "overrides": {
-    "undici": "^6.21.1",
+    "undici": "^6.21.3",
     "@babel/helpers": "^7.26.10"
   }
 }


### PR DESCRIPTION
CVE described below:

```
name: undici
severity: low
isDirect: False
via: [{'source': 1104500, 'name': 'undici', 'dependency': 'undici', 'title': 'undici Denial of Service attack via bad certificate data', 'url': 'https://github.com/advisories/GHSA-cxrh-j4jr-qwg3', 'severity': 'low', 'cwe': ['CWE-401'], 'cvss': {'score': 3.1, 'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L'}, 'range': '>=6.0.0 <6.21.2'}]
effects: []
range: 6.0.0 - 6.21.1
nodes: ['node_modules/undici']
fixAvailable: True 
```