### PR TITLE
BAVL-802: Public/private comments applied to all probation journeys

### DIFF
--- a/integration_tests/e2e/amendBooking.cy.ts
+++ b/integration_tests/e2e/amendBooking.cy.ts
@@ -7,7 +7,6 @@ import courtBookingsForDay from '../mockApis/fixtures/bookAVideoLinkApi/courtBoo
 import probationBookingsForDay from '../mockApis/fixtures/bookAVideoLinkApi/probationBookingsForDay.json'
 import SearchBookingsPage from '../pages/bookAVideoLink/searchBookings'
 import ViewBookingPage from '../pages/bookAVideoLink/viewBooking'
-import AddCommentsPage from '../pages/bookAVideoLink/addComments'
 import UpdateConfirmationPage from '../pages/bookAVideoLink/updateConfirmation'
 import CheckBookingPage from '../pages/bookAVideoLink/checkBooking'
 import ChangeVideoLinkBookingPage from '../pages/bookAVideoLink/changeVideoLinkBooking'
@@ -154,7 +153,7 @@ context('Amend a booking', () => {
       cy.signIn()
     })
 
-    it('Can add comments to a video link booking for a probation team', () => {
+    it('Can add notes to a video link booking for a probation team', () => {
       const home = Page.verifyOnPage(HomePage)
       home.viewAndChangeVideoLinks().click()
 
@@ -163,6 +162,7 @@ context('Amend a booking', () => {
         date: '2050-01-01',
         response: probationBookingsForDay,
       })
+
       const searchBookingsPage = Page.verifyOnPage(SearchBookingsPage)
       searchBookingsPage.selectDate(new Date(2050, 0, 1))
       searchBookingsPage.selectProbationTeam('Blackpool MC (PPOC)')
@@ -170,11 +170,11 @@ context('Amend a booking', () => {
       searchBookingsPage.viewOrEdit().click()
 
       const viewBookingPage = Page.verifyOnPage(ViewBookingPage)
-      viewBookingPage.addComments().click()
+      viewBookingPage.changeNotes().click()
 
-      const addCommentsPage = Page.verifyOnPage(AddCommentsPage)
-      addCommentsPage.enterComments('Test comment')
-      addCommentsPage.continue().click()
+      const notesForStaffPage = Page.verifyOnPage(NotesForStaffPage)
+      notesForStaffPage.enterNotesForStaff('Test notes')
+      notesForStaffPage.continue().click()
 
       Page.verifyOnPage(UpdateConfirmationPage)
     })
@@ -188,6 +188,7 @@ context('Amend a booking', () => {
         date: '2050-01-01',
         response: probationBookingsForDay,
       })
+
       const searchBookingsPage = Page.verifyOnPage(SearchBookingsPage)
       searchBookingsPage.selectDate(new Date(2050, 0, 1))
       searchBookingsPage.selectProbationTeam('Blackpool MC (PPOC)')

--- a/integration_tests/e2e/createBooking.cy.ts
+++ b/integration_tests/e2e/createBooking.cy.ts
@@ -171,6 +171,7 @@ context('Create a booking', () => {
       bookingDetailsPage.selectDate(new Date(2050, 0, 1))
       bookingDetailsPage.selectDuration('1 hour')
       bookingDetailsPage.selectTimePeriods(['Morning', 'Afternoon'])
+      bookingDetailsPage.enterNotesForStaff('staff notes')
       bookingDetailsPage.continue().click()
 
       // Location choices page
@@ -183,7 +184,8 @@ context('Create a booking', () => {
       checkBookingPage.bookVideoLink().click()
 
       // Confirmation of booking page
-      Page.verifyOnPage(ConfirmationPage)
+      const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+      confirmationPage.assertNotesForStaff('staff notes')
     })
   })
 })

--- a/integration_tests/mockApis/fixtures/bookAVideoLinkApi/bobSmithProbationBooking.json
+++ b/integration_tests/mockApis/fixtures/bookAVideoLinkApi/bobSmithProbationBooking.json
@@ -25,6 +25,7 @@
   "probationMeetingType": "RR",
   "probationMeetingTypeDescription": "Recall report",
   "comments": null,
+  "notesForStaff": "staff notes",
   "videoLinkUrl": null,
   "createdByPrison": false,
   "createdBy": "testuser@justice.gov.uk",

--- a/integration_tests/pages/bookAVideoLink/bookingDetails.ts
+++ b/integration_tests/pages/bookAVideoLink/bookingDetails.ts
@@ -35,5 +35,8 @@ export default class BookingDetailsPage extends Page {
 
   selectEndTime = (hour, minute) => this.selectTimePickerTime('End time', hour, minute)
 
+  enterNotesForStaff = (notesForStaff: string) =>
+    this.getByLabel('Notes for prison staff (optional)').type(notesForStaff)
+
   continue = (): PageElement => this.getButton('Continue')
 }

--- a/server/routes/journeys/bookAVideoLink/court/handlers/bookingDetailsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/bookingDetailsHandler.test.ts
@@ -89,7 +89,7 @@ afterEach(() => {
 
 describe('Booking details handler', () => {
   describe('GET', () => {
-    it('should render the correct view page', () => {
+    it('should render the correct view with notes for staff toggled off', () => {
       return request(app)
         .get(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking`)
         .expect('Content-Type', /html/)
@@ -114,7 +114,7 @@ describe('Booking details handler', () => {
         })
     })
 
-    it('should render the correct view page - with notes for staff (feature toggled)', () => {
+    it('should render the correct view with notes for staff toggled on', () => {
       config.featureToggles.masterPublicPrivateNotes = true
       appSetup()
 
@@ -124,7 +124,6 @@ describe('Booking details handler', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           const heading = getPageHeader($)
-          // const html = $.html().valueOf()
 
           expect(heading).toEqual("Select a date and time for Joe Smith's court hearings")
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.BOOKING_DETAILS_PAGE, {

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
 import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
-import { ArrayNotEmpty, Equals, IsEmail, IsNotEmpty, IsOptional, ValidateIf } from 'class-validator'
+import { ArrayNotEmpty, Equals, IsEmail, IsNotEmpty, IsOptional, MaxLength, ValidateIf } from 'class-validator'
 import { isValid, startOfToday } from 'date-fns'
 import { parsePhoneNumberWithError } from 'libphonenumber-js'
 import { Page } from '../../../../../services/auditService'
@@ -13,6 +13,7 @@ import Validator from '../../../../validators/validator'
 import PrisonerService from '../../../../../services/prisonerService'
 import ReferenceDataService from '../../../../../services/referenceDataService'
 import IsValidUkPhoneNumber from '../../../../validators/isValidUkPhoneNumber'
+import config from '../../../../../config'
 
 class Body {
   @Expose()
@@ -91,6 +92,12 @@ class Body {
   @IsValidDate({ message: 'Enter a valid end time' })
   @IsNotEmpty({ message: 'Enter an end time' })
   endTime: Date
+
+  @Expose()
+  @ValidateIf(o => o.notesForStaff && config.featureToggles.masterPublicPrivateNotes)
+  @IsOptional()
+  @MaxLength(400, { message: 'Notes for staff must be $constraint1 characters or less' })
+  notesForStaff: string
 }
 
 export default class BookingDetailsHandler implements PageHandler {
@@ -148,6 +155,7 @@ export default class BookingDetailsHandler implements PageHandler {
       timePeriods,
       startTime,
       endTime,
+      notesForStaff,
     } = req.body
 
     const prisoner =
@@ -176,6 +184,7 @@ export default class BookingDetailsHandler implements PageHandler {
           },
       meetingTypeCode,
       date: date.toISOString(),
+      notesForStaff,
     }
 
     if (mode === 'request') {

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
@@ -3,11 +3,11 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, journeyId, user } from '../../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../../services/auditService'
-import { existsByDataQa, getPageHeader } from '../../../../testutils/cheerio'
+import { existsByDataQa, existsByKey, existsByLabel, getPageHeader } from '../../../../testutils/cheerio'
 import ProbationTeamsService from '../../../../../services/probationTeamsService'
 import PrisonService from '../../../../../services/prisonService'
 import VideoLinkService from '../../../../../services/videoLinkService'
-import { expectErrorMessages } from '../../../../testutils/expectErrorMessage'
+import { expectErrorMessages, expectNoErrorMessages } from '../../../../testutils/expectErrorMessage'
 import {
   AvailabilityResponse,
   Location,
@@ -16,6 +16,7 @@ import {
 } from '../../../../../@types/bookAVideoLinkApi/types'
 import ReferenceDataService from '../../../../../services/referenceDataService'
 import ProbationBookingService from '../../../../../services/probationBookingService'
+import config from '../../../../../config'
 
 jest.mock('../../../../../services/auditService')
 jest.mock('../../../../../services/probationBookingService')
@@ -49,6 +50,8 @@ const appSetup = (journeySession = {}) => {
 }
 
 beforeEach(() => {
+  config.featureToggles.masterPublicPrivateNotes = false
+
   appSetup({
     bookAProbationMeeting: {
       prisoner: { prisonId: 'MDI' },
@@ -68,16 +71,21 @@ describe('Check Booking handler', () => {
       { code: 'P1', description: 'Probation 1' },
       { code: 'P2', description: 'Probation 2' },
     ] as ProbationTeam[])
+
     prisonService.getAppointmentLocations.mockResolvedValue([{ key: 'KEY', description: 'description' }] as Location[])
+
     referenceDataService.getProbationMeetingTypes.mockResolvedValue([
       { code: 'KEY', description: 'description' },
     ] as ReferenceCode[])
+
     probationBookingService.checkAvailability.mockResolvedValue({ availabilityOk: true } as AvailabilityResponse)
+
+    // Used in amend routes only
     videoLinkService.bookingIsAmendable.mockReturnValue(true)
   })
 
   describe('GET', () => {
-    it('should render the correct view page', () => {
+    it('should render the correct view page - with notes for staff toggled off', () => {
       return request(app)
         .get(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
         .expect('Content-Type', /html/)
@@ -86,6 +94,41 @@ describe('Check Booking handler', () => {
           const heading = getPageHeader($)
 
           expect(heading).toEqual('Check and confirm your booking')
+          expect(existsByLabel($, 'Comments (optional)')).toBe(true)
+          expect(existsByKey($, 'Notes for prison staff')).toBe(false)
+
+          expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_BOOKING_PAGE, {
+            who: user.username,
+            correlationId: expect.any(String),
+          })
+
+          expect(probationTeamsService.getUserPreferences).toHaveBeenCalledTimes(2)
+          expect(referenceDataService.getProbationMeetingTypes).toHaveBeenCalledWith(user)
+        })
+    })
+
+    it('should render the correct view page - with notes for staff toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
+
+      appSetup({
+        bookAProbationMeeting: {
+          prisoner: { prisonId: 'MDI' },
+          date: '2024-06-12',
+          startTime: '1970-01-01T16:00',
+        },
+      })
+
+      return request(app)
+        .get(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          const heading = getPageHeader($)
+
+          expect(heading).toEqual('Check and confirm your booking')
+          expect(existsByLabel($, 'Comments (optional)')).toBe(false)
+          expect(existsByKey($, 'Notes for prison staff')).toBe(true)
+
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_BOOKING_PAGE, {
             who: user.username,
             correlationId: expect.any(String),
@@ -156,7 +199,7 @@ describe('Check Booking handler', () => {
   })
 
   describe('POST', () => {
-    it('should validate the comment being too long', () => {
+    it('should validate the comment being too long when staff notes feature is toggled off', () => {
       appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
 
       return request(app)
@@ -173,9 +216,20 @@ describe('Check Booking handler', () => {
         })
     })
 
-    it('should save the posted fields', () => {
+    it('should not validate comments when staff note feature is toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
       appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
 
+      return request(app)
+        .post(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .send({ comments: 'a'.repeat(401) })
+        .expect(() => {
+          expectNoErrorMessages()
+        })
+    })
+
+    it('should save the posted fields when staff note feature is toggled off', () => {
+      appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
       probationBookingService.createVideoLinkBooking.mockResolvedValue(1)
 
       return request(app)
@@ -194,6 +248,28 @@ describe('Check Booking handler', () => {
         })
     })
 
+    it('should not save any comments when staff note feature is toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
+      appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
+      probationBookingService.createVideoLinkBooking.mockResolvedValue(1)
+
+      return request(app)
+        .post(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .send({ comments: 'comment', notesForStaff: 'notes' })
+        .expect(302)
+        .expect('location', 'confirmation/1')
+        .expect(() => {
+          expect(probationBookingService.createVideoLinkBooking).toHaveBeenCalledWith(
+            {
+              comments: undefined,
+              notesForStaff: 'notes',
+              type: 'PROBATION',
+            },
+            user,
+          )
+        })
+    })
+
     it('should redirect to select alternatives if the selected room is not available', () => {
       probationBookingService.checkAvailability.mockResolvedValue({ availabilityOk: false } as AvailabilityResponse)
 
@@ -204,16 +280,9 @@ describe('Check Booking handler', () => {
         .expect('location', 'availability')
     })
 
-    it('should amend the posted fields', () => {
-      const bookAProbationMeeting = {
-        bookingId: 1,
-        date: '2024-06-27',
-        startTime: '15:00',
-      }
-
-      appSetup({
-        bookAProbationMeeting,
-      })
+    it('should amend the posted comments when notes for staff is toggled off', () => {
+      const bookAProbationMeeting = { bookingId: 1, date: '2024-06-27', startTime: '15:00' }
+      appSetup({ bookAProbationMeeting })
 
       return request(app)
         .post(`/probation/booking/amend/1/${journeyId()}/video-link-booking/check-booking`)
@@ -228,7 +297,25 @@ describe('Check Booking handler', () => {
         })
     })
 
-    it('should request a booking using the posted fields', () => {
+    it('should amend the posted notes for staff when feature is toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
+      const bookAProbationMeeting = { bookingId: 1, date: '2024-06-27', startTime: '15:00' }
+      appSetup({ bookAProbationMeeting })
+
+      return request(app)
+        .post(`/probation/booking/amend/1/${journeyId()}/video-link-booking/check-booking`)
+        .send({ notesForStaff: 'notes' })
+        .expect(302)
+        .expect('location', 'confirmation')
+        .expect(() => {
+          expect(probationBookingService.amendVideoLinkBooking).toHaveBeenCalledWith(
+            { ...bookAProbationMeeting, notesForStaff: 'notes', comments: undefined },
+            user,
+          )
+        })
+    })
+
+    it('should request a booking with comments - when staff notes feature is toggled off', () => {
       appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
 
       return request(app)
@@ -241,6 +328,28 @@ describe('Check Booking handler', () => {
             {
               comments: 'comment',
               type: 'PROBATION',
+            },
+            user,
+          )
+
+          expect(probationBookingService.checkAvailability).not.toHaveBeenCalled()
+        })
+    })
+
+    it.skip('should request a booking with staff notes when feature is toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
+      appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
+
+      return request(app)
+        .post(`/probation/booking/request/${journeyId()}/prisoner/video-link-booking/check-booking`)
+        .send({ staffNotes: 'notes' })
+        .expect(302)
+        .expect('location', 'confirmation')
+        .expect(() => {
+          expect(probationBookingService.requestVideoLinkBooking).toHaveBeenCalledWith(
+            {
+              type: 'PROBATION',
+              staffNotes: 'notes',
             },
             user,
           )

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
@@ -342,14 +342,14 @@ describe('Check Booking handler', () => {
 
       return request(app)
         .post(`/probation/booking/request/${journeyId()}/prisoner/video-link-booking/check-booking`)
-        .send({ staffNotes: 'notes' })
+        .send({ notesForStaff: 'notes' })
         .expect(302)
         .expect('location', 'confirmation')
         .expect(() => {
           expect(probationBookingService.requestVideoLinkBooking).toHaveBeenCalledWith(
             {
               type: 'PROBATION',
-              staffNotes: 'notes',
+              notesForStaff: 'notes',
             },
             user,
           )

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/commentsHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/commentsHandler.ts
@@ -1,9 +1,16 @@
 import { Request, Response } from 'express'
 import { Page } from '../../../../../services/auditService'
 import { PageHandler } from '../../../../interfaces/pageHandler'
+import config from '../../../../../config'
 
 export default class CommentsHandler implements PageHandler {
   public PAGE_NAME = Page.COMMENTS_PAGE
 
-  public GET = async (req: Request, res: Response) => res.render('pages/bookAVideoLink/probation/comments')
+  public GET = async (req: Request, res: Response) => {
+    if (config.featureToggles.masterPublicPrivateNotes) {
+      res.render('pages/bookAVideoLink/probation/notesForStaff')
+    } else {
+      res.render('pages/bookAVideoLink/probation/comments')
+    }
+  }
 }

--- a/server/routes/journeys/bookAVideoLink/probation/journey.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/journey.ts
@@ -24,4 +24,5 @@ export type BookAProbationMeetingJourney = {
   endTime?: string
   locationCode?: string
   comments?: string
+  notesForStaff?: string
 }

--- a/server/routes/journeys/bookAVideoLink/probation/middleware/initialiseJourney.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/middleware/initialiseJourney.ts
@@ -50,6 +50,7 @@ export default ({ videoLinkService, prisonerService }: Services): RequestHandler
       endTime: parseTimeToISOString(mainAppointment.endTime),
       locationCode: mainAppointment?.prisonLocKey,
       comments: booking.comments,
+      notesForStaff: booking.notesForStaff,
     }
 
     return next()

--- a/server/services/probationBookingService.test.ts
+++ b/server/services/probationBookingService.test.ts
@@ -112,6 +112,7 @@ describe('Probation booking service', () => {
       probationTeamCode: 'PROBATION_TEAM',
       meetingTypeCode: 'PSR',
       comments: 'comments',
+      notesForStaff: 'staff notes',
     } as BookAProbationMeetingJourney
 
     it('Posts a request to create a probation meeting booking', async () => {
@@ -142,6 +143,7 @@ describe('Probation booking service', () => {
         probationTeamCode: 'PROBATION_TEAM',
         probationMeetingType: 'PSR',
         comments: 'comments',
+        notesForStaff: 'staff notes',
       }
 
       const result = await probationBookingService.createVideoLinkBooking(journey, user)
@@ -173,6 +175,7 @@ describe('Probation booking service', () => {
         probationTeamCode: 'PROBATION_TEAM',
         probationMeetingType: 'PSR',
         comments: 'comments',
+        notesForStaff: 'staff notes',
       }
 
       const result = await probationBookingService.createVideoLinkBooking({ ...journey, officer: undefined }, user)
@@ -204,6 +207,7 @@ describe('Probation booking service', () => {
         probationTeamCode: 'PROBATION_TEAM',
         meetingTypeCode: 'PSR',
         comments: 'comments',
+        notesForStaff: 'staff notes',
       }
 
       const expectedBody = {
@@ -233,6 +237,7 @@ describe('Probation booking service', () => {
         probationTeamCode: 'PROBATION_TEAM',
         probationMeetingType: 'PSR',
         comments: 'comments',
+        notesForStaff: 'staff notes',
       }
 
       await probationBookingService.requestVideoLinkBooking(journey, user)
@@ -262,6 +267,7 @@ describe('Probation booking service', () => {
         probationTeamCode: 'PROBATION_TEAM',
         meetingTypeCode: 'PSR',
         comments: 'comments',
+        notesForStaff: 'staff notes',
       } as BookAProbationMeetingJourney
 
       const expectedBody = {
@@ -289,6 +295,7 @@ describe('Probation booking service', () => {
         probationTeamCode: 'PROBATION_TEAM',
         probationMeetingType: 'PSR',
         comments: 'comments',
+        notesForStaff: 'staff notes',
       }
 
       await probationBookingService.amendVideoLinkBooking(journey, user)

--- a/server/services/probationBookingService.ts
+++ b/server/services/probationBookingService.ts
@@ -89,6 +89,7 @@ export default class ProbationBookingService {
           }
         : undefined,
       comments: journey.comments,
+      notesForStaff: journey.notesForStaff,
     } as unknown as T
   }
 

--- a/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
@@ -7,6 +7,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {% set mode = session.req.params.mode %}
 {% set pageTitle = ("Change" if mode == 'amend' else "Enter") + ' probation video link booking details' %}
@@ -251,6 +252,25 @@
                         ],
                         errorMessage: validationErrors | findError("timePeriods"),
                         classes: "govuk-!-width-one-third"
+                    }) }}
+                {% endif %}
+
+                {# Optional notes for staff - feature switched #}
+                {% if masterPublicPrivateNotes %}
+                    {{ govukCharacterCount({
+                        name: "notesForStaff",
+                        id: "notesForStaff",
+                        maxlength: 400,
+                        label: {
+                            text: "Notes for prison staff (optional)",
+                            classes: 'govuk-fieldset__legend--s'
+                        },
+                        hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
+                        formGroup: {
+                            classes: 'govuk-!-width-two-thirds'
+                        },
+                        errorMessage: validationErrors | findError('notesForStaff'),
+                        value: formResponses.notesForStaff or session.journey.bookAProbationMeeting.notesForStaff
                     }) }}
                 {% endif %}
 

--- a/server/views/pages/bookAVideoLink/probation/checkBooking.njk
+++ b/server/views/pages/bookAVideoLink/probation/checkBooking.njk
@@ -269,7 +269,15 @@
                         value: {
                             text: room.extraAttributes.prisonVideoUrl or "None entered"
                         }
-                    } if mode != 'request'
+                    } if mode != 'request',
+                    {
+                        key: {
+                            text: "Notes for prison staff"
+                        },
+                        value: {
+                            text: session.journey.bookAProbationMeeting.notesForStaff or "None entered"
+                        }
+                    } if masterPublicPrivateNotes
                 ]
             }) }}
 
@@ -282,25 +290,29 @@
                     Updating booking
                 {% endif %}
             {% endset %}
+
             <form method="POST" class="govuk-!-margin-top-6" data-module="form-spinner" data-loading-text="{{ spinnerText }}">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-                {{ govukCharacterCount({
-                    name: "comments",
-                    id: "comments",
-                    maxlength: 400,
-                    label: {
-                        text: "Comments (optional)"
-                    },
-                    hint: {
-                        text: "This can include any other additional information"
-                    },
-                    formGroup: {
-                        classes: 'govuk-!-width-two-thirds'
-                    },
-                    errorMessage: validationErrors | findError('comments'),
-                    value: formResponses.comments or session.journey.bookAProbationMeeting.comments
-                }) }}
+                {# Optional comments - feature switched #}
+                {% if not masterPublicPrivateNotes %}
+                    {{ govukCharacterCount({
+                        name: "comments",
+                        id: "comments",
+                        maxlength: 400,
+                        label: {
+                            text: "Comments (optional)"
+                        },
+                        hint: {
+                            text: "This can include any other additional information"
+                        },
+                        formGroup: {
+                            classes: 'govuk-!-width-two-thirds'
+                        },
+                        errorMessage: validationErrors | findError('comments'),
+                        value: formResponses.comments or session.journey.bookAProbationMeeting.comments
+                    }) }}
+                {% endif %}
 
                 {% set callToActionText %}
                     {% if mode == 'create' %}

--- a/server/views/pages/bookAVideoLink/probation/confirmation.njk
+++ b/server/views/pages/bookAVideoLink/probation/confirmation.njk
@@ -113,8 +113,17 @@
                         value: {
                             text: booking.comments or "None entered"
                         }
+                    } if not masterPublicPrivateNotes,
+                    {
+                        key: {
+                        text: "Notes for prison staff"
+                    },
+                        value: {
+                        text: booking.notesForStaff or "None entered"
                     }
-                ]
+                    } if masterPublicPrivateNotes
+                ],
+                attributes: { 'data-qa': 'confirmation-details' }
             }) }}
 
             <div class="govuk-button-group">

--- a/server/views/pages/bookAVideoLink/probation/notesForStaff.njk
+++ b/server/views/pages/bookAVideoLink/probation/notesForStaff.njk
@@ -1,0 +1,42 @@
+{% extends "partials/layout.njk" %}
+
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = "Change notes on this booking" if session.journey.bookAProbationMeeting.notesForStaff else "Add notes to this booking" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            <form method="POST" action='check-booking' data-module="form-spinner" data-loading-text="Updating notes">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+                {{ govukCharacterCount({
+                    name: "notesForStaff",
+                    id: "notesForStaff",
+                    maxlength: 400,
+                    label: {
+                        text: "Notes for prison staff (optional)",
+                        classes: 'govuk-fieldset__legend--s'
+                    },
+                    hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
+                    value: session.journey.bookAProbationMeeting.notesForStaff
+                }) }}
+
+                {{ govukButton({
+                    text: "Continue",
+                    preventDoubleClick: true,
+                    type: "submit"
+                }) }}
+            </form>
+
+            <a href="/probation/view-booking/{{ session.journey.bookAProbationMeeting.bookingId }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" data-qa='cancel-link'>Cancel</a>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/pages/viewBooking/viewBooking.njk
+++ b/server/views/pages/viewBooking/viewBooking.njk
@@ -236,7 +236,7 @@
                                 }
                             ]
                         } if isAmendable
-                    } if booking.bookingType == 'PROBATION' or masterPublicPrivateNotes != true,
+                    } if masterPublicPrivateNotes != true,
                     {
                         key: {
                             text: "Notes for prison staff"
@@ -253,7 +253,7 @@
                                 }
                             ]
                         } if isAmendable
-                    } if masterPublicPrivateNotes and booking.bookingType == 'COURT'
+                    } if masterPublicPrivateNotes
                 ]
             }) }}
 


### PR DESCRIPTION
This PR implements the changes to cater for public and private comments for the BVLS probation journeys.
BVLS only collects and shows the private comments (or `notesForStaff`) and never shows or enters the public comments ( or `notesForPrisoners`).

Includes changes for all probation journeys:
* Create
* Request
* View
* Edit
* Changes notes
* Cancel

Change notes
![image](https://github.com/user-attachments/assets/fffd62d1-12d5-44c3-a5f2-813cba6cd2f4)

Create
![image](https://github.com/user-attachments/assets/e76f5189-16ee-4c0d-a642-11d35d0bb32f)

View/Edit
![image](https://github.com/user-attachments/assets/a0d623e9-6bfe-4e3c-be98-714661d2b85c)

Confirm
![image](https://github.com/user-attachments/assets/389d5730-0df0-49cf-b64f-7ec9046931c3)
