### PR TITLE
BAVL-908 small consistency tweaks to the change links on the view details page.

### DIFF
--- a/integration_tests/pages/bookAVideoLink/viewBooking.ts
+++ b/integration_tests/pages/bookAVideoLink/viewBooking.ts
@@ -7,7 +7,7 @@ export default class ViewBookingPage extends Page {
 
   addComments = (): PageElement => this.getLink('Add comments')
 
-  changeNotes = (): PageElement => this.getLink('Change notes')
+  changeNotes = (): PageElement => cy.get(`[data-qa="change-notes"]`)
 
   changeBookingDetails = (): PageElement => this.getButton('Change booking details')
 

--- a/server/views/pages/viewBooking/viewBooking.njk
+++ b/server/views/pages/viewBooking/viewBooking.njk
@@ -166,8 +166,9 @@
                             items: [
                                 {
                                     href: '/' + booking.bookingType | lower + '/booking/amend/' + booking.videoLinkBookingId + '/video-link-booking#cvpRequired',
-                                    text: "Change link" if booking.videoLinkUrl else "Add link",
-                                    classes: "govuk-link--no-visited-state"
+                                    text: "Change",
+                                    classes: "govuk-link--no-visited-state",
+                                    attributes: {"data-qa": 'change-cvp-link'}
                                 }
                             ]
                         } if isAmendable
@@ -248,8 +249,9 @@
                             items: [
                                 {
                                     href: '/' + booking.bookingType | lower + '/booking/amend/' + booking.videoLinkBookingId + '/video-link-booking/comments',
-                                    text: "Change notes" if booking.notesForStaff else "Add notes",
-                                    classes: "govuk-link--no-visited-state"
+                                    text: "Change",
+                                    classes: "govuk-link--no-visited-state",
+                                    attributes: {"data-qa": 'change-notes'}
                                 }
                             ]
                         } if isAmendable


### PR DESCRIPTION
Change links should always say 'Change' regardless of whether the field is populated or not.

