### PR TITLE
BAVL-802 this change adds missing validation for notes for staff and comments for both court and probation journeys.

### DIFF
--- a/server/routes/journeys/bookAVideoLink/court/handlers/checkBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/checkBookingHandler.test.ts
@@ -213,6 +213,36 @@ describe('Check Booking handler', () => {
         })
     })
 
+    it('should not validate notes for staff when staff note feature is toggled off', () => {
+      config.featureToggles.masterPublicPrivateNotes = false
+      appSetup({ bookACourtHearing: { type: 'COURT' } })
+
+      return request(app)
+        .post(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .send({ notesForStaff: 'a'.repeat(401) })
+        .expect(() => {
+          expectNoErrorMessages()
+        })
+    })
+
+    it('should validate the notes for staff length when staff note feature is toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
+      appSetup({ bookACourtHearing: { type: 'COURT' } })
+
+      return request(app)
+        .post(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .send({ notesForStaff: 'a'.repeat(401) })
+        .expect(() => {
+          expectErrorMessages([
+            {
+              fieldId: 'notesForStaff',
+              href: '#notesForStaff',
+              text: 'Notes for prison staff must be 400 characters or less',
+            },
+          ])
+        })
+    })
+
     it('should save the posted fields when staff note feature is toggled off', () => {
       appSetup({ bookACourtHearing: { type: 'COURT' } })
       courtBookingService.createVideoLinkBooking.mockResolvedValue(1)

--- a/server/routes/journeys/bookAVideoLink/court/handlers/checkBookingHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/checkBookingHandler.ts
@@ -18,6 +18,12 @@ class Body {
   @IsOptional()
   @MaxLength(400, { message: 'Comments must be $constraint1 characters or less' })
   comments: string
+
+  @Expose()
+  @ValidateIf(o => o.notesForStaff && config.featureToggles.masterPublicPrivateNotes)
+  @IsOptional()
+  @MaxLength(400, { message: 'Notes for prison staff must be $constraint1 characters or less' })
+  notesForStaff: string
 }
 
 export default class CheckBookingHandler implements PageHandler {

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
@@ -228,6 +228,36 @@ describe('Check Booking handler', () => {
         })
     })
 
+    it('should validate notes for staff being too long when staff notes feature is toggled on', () => {
+      config.featureToggles.masterPublicPrivateNotes = true
+      appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
+
+      return request(app)
+        .post(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .send({ notesForStaff: 'a'.repeat(401) })
+        .expect(() => {
+          expectErrorMessages([
+            {
+              fieldId: 'notesForStaff',
+              href: '#notesForStaff',
+              text: 'Notes for prison staff must be 400 characters or less',
+            },
+          ])
+        })
+    })
+
+    it('should not validate notes for staff when staff note feature is toggled off', () => {
+      config.featureToggles.masterPublicPrivateNotes = false
+      appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
+
+      return request(app)
+        .post(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .send({ notesForStaff: 'a'.repeat(401) })
+        .expect(() => {
+          expectNoErrorMessages()
+        })
+    })
+
     it('should save the posted fields when staff note feature is toggled off', () => {
       appSetup({ bookAProbationMeeting: { type: 'PROBATION' } })
       probationBookingService.createVideoLinkBooking.mockResolvedValue(1)

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.ts
@@ -18,6 +18,12 @@ class Body {
   @IsOptional()
   @MaxLength(400, { message: 'Comments must be $constraint1 characters or less' })
   comments: string
+
+  @Expose()
+  @ValidateIf(o => o.notesForStaff && config.featureToggles.masterPublicPrivateNotes)
+  @IsOptional()
+  @MaxLength(400, { message: 'Notes for prison staff must be $constraint1 characters or less' })
+  notesForStaff: string
 }
 
 export default class CheckBookingHandler implements PageHandler {

--- a/server/views/pages/bookAVideoLink/court/comments.njk
+++ b/server/views/pages/bookAVideoLink/court/comments.njk
@@ -21,9 +21,10 @@
                     name: "comments",
                     id: "comments",
                     maxlength: 400,
+                    errorMessage: validationErrors | findError("comments"),
                     label: { text: "Comments (optional)" },
                     hint: { text: "This might include case number, co-defendant details if this is a multi-handed case, or whether you have borrowed another court’s room." },
-                    value: session.journey.bookACourtHearing.comments
+                    value: formResponses.comments or session.journey.bookACourtHearing.comments
                 }) }}
 
                 {{ govukButton({

--- a/server/views/pages/bookAVideoLink/court/notesForStaff.njk
+++ b/server/views/pages/bookAVideoLink/court/notesForStaff.njk
@@ -21,12 +21,13 @@
                     name: "notesForStaff",
                     id: "notesForStaff",
                     maxlength: 400,
+                    errorMessage: validationErrors | findError("notesForStaff"),
                     label: {
                         text: "Notes for prison staff (optional)",
                         classes: 'govuk-fieldset__legend--s'
                     },
                     hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
-                    value: session.journey.bookACourtHearing.notesForStaff
+                    value: formResponses.notesForStaff or session.journey.bookACourtHearing.notesForStaff
                 }) }}
 
                 {{ govukButton({

--- a/server/views/pages/bookAVideoLink/probation/comments.njk
+++ b/server/views/pages/bookAVideoLink/probation/comments.njk
@@ -21,8 +21,9 @@
                     name: "comments",
                     id: "comments",
                     maxlength: 400,
+                    errorMessage: validationErrors | findError("comments"),
                     label: { text: "Comments (optional)" },
-                    value: session.journey.bookAProbationMeeting.comments
+                    value: formResponses.comments or session.journey.bookAProbationMeeting.comments
                 }) }}
 
                 {{ govukButton({

--- a/server/views/pages/bookAVideoLink/probation/notesForStaff.njk
+++ b/server/views/pages/bookAVideoLink/probation/notesForStaff.njk
@@ -21,12 +21,13 @@
                     name: "notesForStaff",
                     id: "notesForStaff",
                     maxlength: 400,
+                    errorMessage: validationErrors | findError("notesForStaff"),
                     label: {
                         text: "Notes for prison staff (optional)",
                         classes: 'govuk-fieldset__legend--s'
                     },
                     hint: { text: "This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required." },
-                    value: session.journey.bookAProbationMeeting.notesForStaff
+                    value: formResponses.notesForStaff or session.journey.bookAProbationMeeting.notesForStaff
                 }) }}
 
                 {{ govukButton({


### PR DESCRIPTION
It looks like we were missing the UI validation for comments before the notes changes (it was still caught but via the API).

**Court comments validation:**
![court-comments](https://github.com/user-attachments/assets/d52eda59-f969-4f6a-a645-90ff5e26e184)

**Court notes for staff validation:**
![court-notes-for-staff](https://github.com/user-attachments/assets/f83572aa-4b2c-4928-a8f2-174b8d3122f3)

**Probation comments validation:**
![probation-comments](https://github.com/user-attachments/assets/028ffc92-e748-4748-9d44-77d767f34920)

**Probation notes for staff validation:**
![probation-notes-for-staff](https://github.com/user-attachments/assets/8095c59f-ef49-4175-9ed4-cc73b7681082)

