### PR TITLE
BAVL-866: Update link text to include "opens in new tab"

### DIFF
--- a/server/views/partials/beforeContent.njk
+++ b/server/views/partials/beforeContent.njk
@@ -10,9 +10,9 @@
   },
   classes: 'govuk-!-display-none-print',
   html: '
-          <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Provide feedback<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
+          <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Provide feedback (opens in a new tab)</a>
           or
-          <a href="' + reportAFaultUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">report a fault<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
+          <a href="' + reportAFaultUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">report a fault (opens in a new tab)</a>
           to help us improve this service.
         '
 }) }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3d5a7da2-921b-4126-8dab-7cc7784e3194)