### PR TITLE
BAVL-884 remove change link for prisoner on amend journey. You cannot change the prisoner on an existing booking as this effectively changes the whole booking.

### DIFF
--- a/integration_tests/e2e/amendBooking.cy.ts
+++ b/integration_tests/e2e/amendBooking.cy.ts
@@ -19,7 +19,6 @@ import SelectRoomsPage from '../pages/bookAVideoLink/selectRoomsPage'
 import NoRoomsAvailablePage from '../pages/bookAVideoLink/noRoomsAvailablePage'
 import nottinghamSelectRoomsByDateTimeEmpty from '../mockApis/fixtures/bookAVideoLinkApi/nottinghamSelectRoomsByDateTimeEmpty.json'
 import NotesForStaffPage from '../pages/bookAVideoLink/notesForStaff'
-import SearchPrisonerPage from '../pages/bookAVideoLink/searchPrisoner'
 
 context('Amend a booking', () => {
   beforeEach(() => {
@@ -164,7 +163,6 @@ context('Amend a booking', () => {
       const viewBookingPage = Page.verifyOnPage(ViewBookingPage)
 
       const pageMappings: CourtNavigationTest[] = [
-        { summaryListKey: 'Prisoner name', expectedPage: SearchPrisonerPage },
         { summaryListKey: 'Hearing type', expectedPage: ChangeVideoLinkBookingPage },
         { summaryListKey: 'Date', expectedPage: ChangeVideoLinkBookingPage },
         { summaryListKey: 'Pre-court hearing room', expectedPage: SelectRoomsPage },

--- a/server/views/pages/viewBooking/viewBooking.njk
+++ b/server/views/pages/viewBooking/viewBooking.njk
@@ -34,17 +34,7 @@
                         },
                         value: {
                             text: ((prisoner.firstName + " " + prisoner.lastName) | convertToTitleCase) + ' (' + prisoner.prisonerNumber + ')'
-                        },
-                        actions: {
-                            items: [
-                                {
-                                    href: '/court/prisoner-search/search',
-                                    text: "Change",
-                                    classes: "govuk-link--no-visited-state",
-                                    attributes: {"data-qa": 'change-prisoner'}
-                                }
-                            ]
-                        } if isAmendable
+                        }
                     },
                     {
                         key: {


### PR DESCRIPTION
You cannot change the prisoner on a existing booking. In doing so you would be effectively be recreating the whole booking from scratch.  The path here would be to cancel the booking (if appropriate) and create a new one.

![image](https://github.com/user-attachments/assets/c7aa5b82-b026-44c0-b03f-1883d798a7da)
