### PR TITLE
BAVL-884 change link for the guest pin should only be present when booking can be amended.

### DIFF
--- a/server/views/pages/viewBooking/viewBooking.njk
+++ b/server/views/pages/viewBooking/viewBooking.njk
@@ -240,7 +240,7 @@
                                     attributes: {"data-qa": 'change-guest-pin'}
                                 }
                             ]
-                         }
+                         } if isAmendable
                     } if booking.bookingType == 'COURT' and hmctsLinkAndGuestPin,
                     {
                         key: {


### PR DESCRIPTION
Noticed during testing, change link was visible for guest pin when it shouldn't have been:

![image](https://github.com/user-attachments/assets/b29ac8ee-480b-44ed-8c15-ae99bd52c86f)
