### PR TITLE
BAVL-884 remove change link for prisoner on amend journey. You cannot change the prisoner on an existing booking as this effectively changes the whole booking.

### DIFF
--- a/integration_tests/e2e/createBooking.cy.ts
+++ b/integration_tests/e2e/createBooking.cy.ts
@@ -177,10 +177,6 @@ context('Create a booking', () => {
       const checkBookingPage = Page.verifyOnPage(CheckBookingPage)
 
       // Verify change links navigate to the relevant pages
-      checkBookingPage.changeLinkFor('Name').click()
-      Page.verifyOnPage(SearchPrisonerPage)
-      cy.go('back')
-
       checkBookingPage.changeLinkFor('Hearing type').click()
       Page.verifyOnPage(NewBookingPage)
       cy.go('back')

--- a/server/views/pages/bookAVideoLink/court/checkBooking.njk
+++ b/server/views/pages/bookAVideoLink/court/checkBooking.njk
@@ -58,15 +58,6 @@
                         },
                         value: {
                             text: ((prisoner.firstName + " " + prisoner.lastName) | convertToTitleCase) + ((' (' + prisoner.prisonerNumber + ')') if prisoner.prisonerNumber)
-                        },
-                        actions: {
-                            items: [
-                                {
-                                    href: "/court/prisoner-search/search",
-                                    classes: 'govuk-link--no-visited-state',
-                                    text: "Change"
-                                }
-                            ]
                         }
                     },
                     {


### PR DESCRIPTION
Removes the change link from the check booking page on court bookings.  You cannot change a prisoner on a booking.

![image](https://github.com/user-attachments/assets/1aeb78c2-0321-4cd4-9b7f-722a16eb1b62)
