### PR TITLE
BAVL-902 small content fix for the guest pin radio and video link label.

### DIFF
--- a/integration_tests/pages/bookAVideoLink/changeVideoLinkBooking.ts
+++ b/integration_tests/pages/bookAVideoLink/changeVideoLinkBooking.ts
@@ -9,7 +9,7 @@ export default class ChangeVideoLinkBookingPage extends Page {
 
   selectCvpKnown = (yesOrNo: string) =>
     cy
-      .contains('legend', 'Do you know the link for this video link hearing?')
+      .contains('legend', 'Do you know the video link for this hearing?')
       .parent()
       .within(() => this.getByLabel(yesOrNo).click())
 

--- a/integration_tests/pages/bookAVideoLink/newBooking.ts
+++ b/integration_tests/pages/bookAVideoLink/newBooking.ts
@@ -11,7 +11,7 @@ export default class NewBookingPage extends Page {
 
   selectCvpKnown = (yesOrNo: string) =>
     cy
-      .contains('legend', 'Do you know the link for this video link hearing?')
+      .contains('legend', 'Do you know the video link for this hearing?')
       .parent()
       .within(() => this.getByLabel(yesOrNo).click())
 

--- a/server/views/pages/bookAVideoLink/court/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/court/bookingDetails.njk
@@ -181,9 +181,6 @@
                             text: "Enter guest pin",
                             classes: 'govuk-label--s'
                         },
-                        hint: {
-                          text: "Some meetings require a guest pin for security reasons"
-                        },
                         inputmode: "numeric",
                         classes: 'govuk-input--width-10',
                         errorMessage: validationErrors | findError('guestPin'),
@@ -197,7 +194,7 @@
                     errorMessage: validationErrors | findError('cvpRequired'),
                     fieldset: {
                         legend: {
-                            text: "Do you know the link for this video link hearing?",
+                            text: "Do you know the video link for this hearing?",
                             classes: "govuk-fieldset__legend--s"
                         }
                     },
@@ -228,6 +225,9 @@
                                 text: "Is a guest pin required?",
                                 classes: "govuk-fieldset__legend--s"
                             }
+                        },
+                        hint: {
+                            text: "Some meetings require a guest pin for security reasons."
                         },
                         items: [
                             {


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/998f01bc-fff6-49fd-9459-580cc4162e70)

After:
![after](https://github.com/user-attachments/assets/a0cc415b-32fe-4687-8507-85468168cf84)
