### PR TITLE
BAVL-997: Fix issue where missing link alert still shown when a HMCTS number is present.

### DIFF
--- a/server/views/pages/viewBooking/viewDailyBookings.njk
+++ b/server/views/pages/viewBooking/viewDailyBookings.njk
@@ -79,7 +79,7 @@
                             { text: item.startTime + ' to ' + item.endTime, attributes: { 'data-sort-value': item.startTime | parseDate('HH:mm') | formatDate("HHmm") } },
                             { text: item.prisonerName | convertToTitleCase },
                             { html: '<div>'+ item.prisonLocationDescription +'</div><div class="govuk-hint govuk-!-margin-bottom-0">' + item.prisonName + '</div>' +
-                                    ('<strong class="govuk-tag govuk-tag--red govuk-tag--small">Action: provide hearing link</strong>' if item.appointmentType == 'VLB_COURT_MAIN' and not item.videoUrl) },
+                                    ('<strong class="govuk-tag govuk-tag--red govuk-tag--small">Action: provide hearing link</strong>' if item.appointmentType == 'VLB_COURT_MAIN' and not item.videoUrl and not item.hmctsNumber) },
                             { html: '<div>' + (item.hearingTypeDescription or item.probationMeetingTypeDescription) + '</div>' +
                                     ('<strong class="govuk-tag govuk-tag--small">Pre-court hearing</strong>' if item.appointmentType == 'VLB_COURT_PRE') +
                                     ('<strong class="govuk-tag govuk-tag--small">Post-court hearing</strong>' if item.appointmentType == 'VLB_COURT_POST') },


### PR DESCRIPTION
We were showing these action links even when HMCTS numbers were present. This PR now takes the URL or HMCTS numbers into account when deciding whether to show the warning message.

<img width="1033" height="567" alt="image" src="https://github.com/user-attachments/assets/1fb869dd-ec71-475a-ae10-710e5407c8ad" />
 