### PR TITLE
BAV-1014: Expand prison room video url to 300 characters

### DIFF
--- a/server/routes/journeys/admin/handlers/shared/roomAndScheduleRequestBody.ts
+++ b/server/routes/journeys/admin/handlers/shared/roomAndScheduleRequestBody.ts
@@ -13,7 +13,7 @@ export default class RoomAndScheduleRequestBody {
 
   @Expose()
   @ValidateIf(o => o.videoUrl)
-  @MaxLength(120, { message: 'The room link must be less than 120 characters' })
+  @MaxLength(300, { message: 'The room link must be less than 300 characters' })
   videoUrl: string
 
   @Expose()


### PR DESCRIPTION
Minor change - validate prison video URL to 300 character max instead of 120.
May need API types updating? Maybe not..