### PR TITLE
BAVL-1025 the feeback link is no longer needed.  UR has shown it is no longer being used.

### DIFF
--- a/server/views/partials/beforeContent.njk
+++ b/server/views/partials/beforeContent.njk
@@ -10,9 +10,7 @@
   },
   classes: 'govuk-!-display-none-print',
   html: '
-          <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Provide feedback (opens in a new tab)</a>
-          or
-          <a href="' + reportAFaultUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">report a fault (opens in a new tab)</a>
+          <a href="' + reportAFaultUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Report a fault (opens in a new tab)</a>
           to help us improve this service.
         '
 }) }}


### PR DESCRIPTION
before
<img width="3910" height="1764" alt="bvls-before" src="https://github.com/user-attachments/assets/e280f05a-a137-4864-94d3-db1fdc266ea5" />

after
<img width="3910" height="1764" alt="bvls-after" src="https://github.com/user-attachments/assets/d0e78498-7ae4-457c-8500-69b881a793f8" />

