### PR TITLE
BAVL-1038 correct default sort order to be applied to the new rooms column.

### DIFF
--- a/server/routes/journeys/admin/handlers/viewPrisonsHandler.ts
+++ b/server/routes/journeys/admin/handlers/viewPrisonsHandler.ts
@@ -23,6 +23,5 @@ export default class ViewPrisonsHandler implements PageHandler {
   }
 
   // A room is considered new when it lacks extra attributes (i.e., undecorated).
-  private new = (rooms: Location[]) =>
-    rooms.filter(r => r.extraAttributes === undefined || r.extraAttributes === null).length
+  private new = (rooms: Location[]) => rooms.filter(r => r.extraAttributes == null).length
 }

--- a/server/views/pages/admin/viewPrisons.njk
+++ b/server/views/pages/admin/viewPrisons.njk
@@ -49,9 +49,9 @@
                             'data-module': 'moj-sortable-table'
                         },
                         head: [
-                            { text: "Prison", attributes: { "aria-sort": "ascending" } },
+                            { text: "Prison", attributes: { "aria-sort": "none" } },
                             { text: "Prison code" },
-                            { text: "New video rooms", attributes: { "aria-sort": "ascending" } },
+                            { text: "New video rooms", attributes: { "aria-sort": "descending" } },
                             { html: "Action" }
                         ],
                         rows: rows


### PR DESCRIPTION
This change fixes the default sort order (now that I know how to do it).

**Before:**
<img width="4504" height="3238" alt="after" src="https://github.com/user-attachments/assets/88058298-3a5d-4ebc-9d14-6c6f279fb724" />

**After**:
<img width="4032" height="3238" alt="image" src="https://github.com/user-attachments/assets/2cdff13f-5519-4a0c-bf6e-d29405a8a9be" />


