### PR TITLE
BAVL-1084 fix minor CVP details validation

### DIFF
--- a/server/routes/journeys/bookAVideoLink/court/handlers/bookingDetailsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/bookingDetailsHandler.test.ts
@@ -369,6 +369,62 @@ describe('Booking details handler', () => {
         })
     })
 
+    it('should validate HMCTS number is numeric', () => {
+      return request(app)
+        .post(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking`)
+        .send({
+          ...validForm,
+          videoLinkUrl: null,
+          hmctsNumber: 'NaN',
+        })
+        .expect(() => {
+          expectErrorMessages([
+            {
+              fieldId: 'hmctsNumber',
+              href: '#hmctsNumber',
+              text: 'Number from CVP address must be a number, like 3457',
+            },
+          ])
+        })
+    })
+
+    it('should validate HMCTS number is positive number', () => {
+      return request(app)
+        .post(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking`)
+        .send({
+          ...validForm,
+          videoLinkUrl: null,
+          hmctsNumber: '-1',
+        })
+        .expect(() => {
+          expectErrorMessages([
+            {
+              fieldId: 'hmctsNumber',
+              href: '#hmctsNumber',
+              text: 'Number from CVP address must be a number, like 3457',
+            },
+          ])
+        })
+    })
+
+    it('should validate that a CVP link or HMCTS number is provided', () => {
+      return request(app)
+        .post(`/court/booking/create/${journeyId()}/A1234AA/video-link-booking`)
+        .send({
+          ...validForm,
+          videoLinkUrl: null,
+        })
+        .expect(() => {
+          expectErrorMessages([
+            {
+              fieldId: 'cvpRequired',
+              href: '#cvpRequired',
+              text: 'Enter number from CVP address or enter full web address (URL)',
+            },
+          ])
+        })
+    })
+
     it('should save the posted fields in session', async () => {
       appSetup()
 

--- a/server/views/pages/bookAVideoLink/court/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/court/bookingDetails.njk
@@ -138,7 +138,7 @@
                         inputmode: "numeric",
                         classes: 'govuk-input--width-5',
                         errorMessage: validationErrors | findError('hmctsNumber'),
-                        value: formResponses.hmctsNumber or session.journey.bookACourtHearing.hmctsNumber
+                        value: formResponses.hmctsNumber if (formResponses.cvpRequired == 'yes') else session.journey.bookACourtHearing.hmctsNumber
                     }) }}
 
                     <p>Or</p>
@@ -155,7 +155,7 @@
                         },
                         classes: 'govuk-!-width-three-quarters',
                         errorMessage: validationErrors | findError('videoLinkUrl'),
-                        value: formResponses.videoLinkUrl or session.journey.bookACourtHearing.videoLinkUrl
+                        value: formResponses.videoLinkUrl if (formResponses.cvpRequired == 'yes') else session.journey.bookACourtHearing.videoLinkUrl
                     }) }}
                 {% endset %}
 


### PR DESCRIPTION
This is a minor issue but would be nice to fix.

During editing of a court booking with a CVP link or HMCTS number and hit continue it repopulates the fields you cleared out with those from the session but still shows the error please provide a link.

This should not happen, the fields should remain blank.

**In the screen shot below from dev I cleared the HMCTS number and hit continue**
<img width="1790" height="2014" alt="image" src="https://github.com/user-attachments/assets/358ca9a3-0641-44b0-b0c4-9d13862b9f38" />

**After testing changes locally**
<img width="1894" height="2014" alt="image" src="https://github.com/user-attachments/assets/6394b191-29ce-41cc-bfa0-4ccdf396bc4f" />
