### PR TITLE
BAVL-1269 undecorated (default) rooms now default to out of use instead of active.

### DIFF
--- a/integration_tests/specs/administration.spec.ts
+++ b/integration_tests/specs/administration.spec.ts
@@ -234,7 +234,7 @@ test.describe('Administration', () => {
       const viewRoomsPage = await ViewRoomsPage.verifyOnPage(page)
       await viewRoomsPage.viewOrEditLink('f1c78dca-733b-43cc-b03f-6c870941a2c7').click()
       const editRoomPage = await EditRoomPage.verifyOnPage(page)
-      await editRoomPage.assertSelectedRoomStatus('active')
+      await editRoomPage.assertSelectedRoomStatus('inactive')
       await editRoomPage.selectRoomStatus('temporarily_blocked')
       await editRoomPage.selectBlockedFromDate(new Date())
       await editRoomPage.selectBlockedToDate(new Date())

--- a/server/routes/journeys/admin/handlers/viewPrisonRoomHandler.test.ts
+++ b/server/routes/journeys/admin/handlers/viewPrisonRoomHandler.test.ts
@@ -84,7 +84,7 @@ describe('View prison room handler', () => {
           expect(permissionRadios.length).toBe(4)
 
           const defaultStatus = $("input[type='radio'][name='roomStatus']:checked").val()
-          expect(defaultStatus).toBe('active')
+          expect(defaultStatus).toBe('inactive')
 
           const defaultPermission = $("input[type='radio'][name='permission']:checked").val()
           expect(defaultPermission).toBe('shared')

--- a/server/views/pages/admin/prisonRoomDecorations.njk
+++ b/server/views/pages/admin/prisonRoomDecorations.njk
@@ -84,12 +84,12 @@
                         {
                             value: "active",
                             text: "Active",
-                            checked: formResponses.roomStatus == 'active' or room.extraAttributes.locationStatus == "ACTIVE" or (not room.extraAttributes and not formResponses)
+                            checked: formResponses.roomStatus == 'active' or room.extraAttributes.locationStatus == "ACTIVE"
                         },
                         {
                             value: "inactive",
                             text: "Out of use",
-                            checked: formResponses.roomStatus == 'inactive' or room.extraAttributes.locationStatus == "INACTIVE"
+                            checked: formResponses.roomStatus == 'inactive' or room.extraAttributes.locationStatus == "INACTIVE" or (not room.extraAttributes and not formResponses)
                         },
                         {
                             value: "temporarily_blocked",

--- a/server/views/pages/admin/viewPrisonLocations.njk
+++ b/server/views/pages/admin/viewPrisonLocations.njk
@@ -34,12 +34,11 @@
                             {% if result.extraAttributes.locationStatus == 'ACTIVE' %}
                                 {{ locationUsageTag("Active", "govuk-tag--green") }}
                             {% elseif result.extraAttributes.locationStatus == 'INACTIVE' %}
-                                {{ locationUsageTag("Out of use", "govuk-tag--red") }}
                             {% else  %}
                                 {{ locationUsageTag("Blocked", "govuk-tag--yellow") }}
                             {% endif %}
                         {% else %}
-                            {{ locationUsageTag("Active", "govuk-tag--green") }}
+                            {{ locationUsageTag("Out of use", "govuk-tag--red") }}
                         {% endif %}
                     {% endset %}
 


### PR DESCRIPTION
This change means undecorated rooms now default to `out of use` by default instead of `active`.

This change has come about as a result of new rooms being added incorrectly in external services which have then been used inadvertently by users of BVLS when they shouldn't.

<img width="2460" height="1276" alt="Screenshot 2026-04-27 at 11-23-48 Edit video link rooms at Elmley (HMP   YOI) Book A Video Link MoJ" src="https://github.com/user-attachments/assets/59260974-9c62-4ba8-ace2-3788c97a0beb" />

<img width="2308" height="2490" alt="Screenshot 2026-04-27 at 11-24-16 VCC - Maidstone Crown Conf - Room 9 Book A Video Link MoJ" src="https://github.com/user-attachments/assets/dabe45eb-36a0-45c3-b799-d4c0e4909fb3" />
