### PR TITLE
BAVL-1269 adding line back into template for inactive out of use rooms which was removed in error.

### DIFF
--- a/server/views/pages/admin/viewPrisonLocations.njk
+++ b/server/views/pages/admin/viewPrisonLocations.njk
@@ -34,6 +34,7 @@
                             {% if result.extraAttributes.locationStatus == 'ACTIVE' %}
                                 {{ locationUsageTag("Active", "govuk-tag--green") }}
                             {% elseif result.extraAttributes.locationStatus == 'INACTIVE' %}
+                                {{ locationUsageTag("Out of use", "govuk-tag--red") }}
                             {% else  %}
                                 {{ locationUsageTag("Blocked", "govuk-tag--yellow") }}
                             {% endif %}


### PR DESCRIPTION
Before:

<img width="2460" height="1276" alt="image" src="https://github.com/user-attachments/assets/7286296d-f5a9-426f-b873-95fc55ac17f5" />

After:

<img width="2460" height="1276" alt="image" src="https://github.com/user-attachments/assets/9f3cdccb-51f2-4e49-be1e-5dc86ec70562" />
