### PR TITLE
BAVL-1338 changed capture of probation officer details from checkbox to conditional radio.

### DIFF
--- a/integration_tests/pages/bookAVideoLink/bookingDetails.ts
+++ b/integration_tests/pages/bookAVideoLink/bookingDetails.ts
@@ -34,12 +34,24 @@ export default class BookingDetailsPage extends AbstractPage {
   static async verifyOnPage(page: Page): Promise<BookingDetailsPage> {
     const bookingDetailsPage = new BookingDetailsPage(page)
     await expect(bookingDetailsPage.header).toBeVisible()
-    await bookingDetailsPage.verifyNoAccessViolationsOnPage()
+    // // aria-allowed-attr is disabled because radio buttons can have aria-expanded which isn't
+    // // currently allowed by the spec, but that might change: https://github.com/w3c/aria/issues/1404
+    await bookingDetailsPage.verifyNoAccessViolationsOnPage(['aria-allowed-attr'])
     return bookingDetailsPage
   }
 
   async selectProbationTeam(probationTeam: string) {
     await this.probationTeam.selectOption(probationTeam)
+  }
+
+  async selectProbationOfficerDetailsKnown(yesOrNo: string) {
+    if (yesOrNo === 'Yes') {
+      await this.page.locator('#probationOfficerDetailsKnown').check()
+    }
+
+    if (yesOrNo === 'No') {
+      await this.page.locator('#probationOfficerDetailsKnown-2').check()
+    }
   }
 
   async enterProbationOfficerName(name: string) {

--- a/integration_tests/specs/createBooking.spec.ts
+++ b/integration_tests/specs/createBooking.spec.ts
@@ -254,6 +254,7 @@ test.describe('Create a booking', () => {
 
       const bookingDetailsPage = await BookingDetailsPage.verifyOnPage(page)
       await bookingDetailsPage.selectProbationTeam('Blackpool MC (PPOC)')
+      await bookingDetailsPage.selectProbationOfficerDetailsKnown('Yes')
       await bookingDetailsPage.enterProbationOfficerName('Alan Key')
       await bookingDetailsPage.enterProbationOfficerEmail('akey@justice.gov.uk')
       await bookingDetailsPage.selectProbationMeetingType('Recall report (PRARR - parts B or C)')

--- a/integration_tests/specs/requestBooking.spec.ts
+++ b/integration_tests/specs/requestBooking.spec.ts
@@ -116,6 +116,7 @@ test.describe('Request a booking', () => {
       const bookingDetailsPage = await BookingDetailsPage.verifyOnPage(page)
 
       await bookingDetailsPage.selectProbationTeam('Blackpool MC (PPOC)')
+      await bookingDetailsPage.selectProbationOfficerDetailsKnown('Yes')
       await bookingDetailsPage.enterProbationOfficerName('Alan Key')
       await bookingDetailsPage.enterProbationOfficerEmail('akey@justice.gov.uk')
       await bookingDetailsPage.selectProbationMeetingType('Recall report (PRARR - parts B or C)')

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.test.ts
@@ -251,6 +251,7 @@ describe('Booking details handler', () => {
       date: formatDate(startOfTomorrow(), 'dd/MM/yyyy'),
       duration: '120',
       timePeriods: ['AM'],
+      probationOfficerDetailsKnown: 'yes',
     }
 
     it('should validate an empty form', () => {
@@ -265,9 +266,9 @@ describe('Booking details handler', () => {
               text: 'Select a probation team',
             },
             {
-              fieldId: 'officerDetailsOrUnknown',
-              href: '#officerDetailsOrUnknown',
-              text: "Enter the probation officer's details",
+              fieldId: 'probationOfficerDetailsKnown',
+              href: '#probationOfficerDetailsKnown',
+              text: 'Select if you know the details of the probation officer',
             },
             {
               fieldId: 'meetingTypeCode',
@@ -288,24 +289,6 @@ describe('Booking details handler', () => {
               fieldId: 'timePeriods',
               href: '#timePeriods',
               text: 'Select at least one time period',
-            },
-          ])
-        })
-    })
-
-    it('should validate that both `not yet known` and some details can be entered for probation officer details', () => {
-      return request(app)
-        .post(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking`)
-        .send({
-          ...validForm,
-          officerDetailsNotKnown: 'true',
-        })
-        .expect(() => {
-          expectErrorMessages([
-            {
-              fieldId: 'officerDetailsOrUnknown',
-              href: '#officerDetailsOrUnknown',
-              text: `Enter either the probation officer's details, or select 'Not yet known'`,
             },
           ])
         })
@@ -466,7 +449,7 @@ describe('Booking details handler', () => {
               prisonName: 'Moorland',
               prisonerNumber: 'A1234AA',
             },
-            officerDetailsNotKnown: false,
+            probationOfficerDetailsKnown: true,
             officer: {
               fullName: 'John Bing',
               email: 'jbing@gmail.com',
@@ -484,7 +467,7 @@ describe('Booking details handler', () => {
         .post(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking`)
         .send({
           ...validForm,
-          officerDetailsNotKnown: 'true',
+          probationOfficerDetailsKnown: 'no',
           officerFullName: '',
           officerEmail: '',
           officerTelephone: '',
@@ -507,7 +490,7 @@ describe('Booking details handler', () => {
               prisonName: 'Moorland',
               prisonerNumber: 'A1234AA',
             },
-            officerDetailsNotKnown: true,
+            probationOfficerDetailsKnown: false,
             duration: 120,
             timePeriods: ['AM'],
           }),
@@ -539,7 +522,7 @@ describe('Booking details handler', () => {
               prisonName: 'Moorland',
               prisonerNumber: 'A1234AA',
             },
-            officerDetailsNotKnown: false,
+            probationOfficerDetailsKnown: true,
             officer: {
               fullName: 'John Bing',
               email: 'jbing@gmail.com',
@@ -595,7 +578,7 @@ describe('Booking details handler', () => {
               prisonId: 'MDI',
               prisonName: 'Moorland',
             },
-            officerDetailsNotKnown: false,
+            probationOfficerDetailsKnown: true,
             officer: {
               fullName: 'John Bing',
               email: 'jbing@gmail.com',

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
 import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
-import { ArrayNotEmpty, Equals, IsEmail, IsNotEmpty, IsOptional, MaxLength, ValidateIf } from 'class-validator'
+import { ArrayNotEmpty, IsEmail, IsEnum, IsNotEmpty, IsOptional, MaxLength, ValidateIf } from 'class-validator'
 import { isValid, startOfToday } from 'date-fns'
 import { parsePhoneNumberWithError } from 'libphonenumber-js'
 import { Page } from '../../../../../services/auditService'
@@ -13,6 +13,7 @@ import Validator from '../../../../validators/validator'
 import PrisonerService from '../../../../../services/prisonerService'
 import ReferenceDataService from '../../../../../services/referenceDataService'
 import IsValidUkPhoneNumber from '../../../../validators/isValidUkPhoneNumber'
+import YesNo from '../../../../enumerator/yesNo'
 
 class Body {
   @Expose()
@@ -20,32 +21,25 @@ class Body {
   probationTeamCode: string
 
   @Expose()
-  @Transform(({ obj }) =>
-    !obj.officerDetailsNotKnown && !obj.officerFullName && !obj.officerEmail && !obj.officerTelephone
-      ? null
-      : !!obj.officerDetailsNotKnown !== !!(obj.officerFullName || obj.officerEmail || obj.officerTelephone),
-  )
-  @Equals(true, { message: `Enter either the probation officer's details, or select 'Not yet known'` })
-  @IsNotEmpty({ message: "Enter the probation officer's details" })
-  officerDetailsOrUnknown: boolean
+  @IsEnum(YesNo, { message: 'Select if you know the details of the probation officer' })
+  probationOfficerDetailsKnown: string
 
   @Expose()
-  @Transform(({ value }) => value === 'true')
-  officerDetailsNotKnown: boolean
-
-  @Expose()
-  @ValidateIf(o => o.officerDetailsOrUnknown && !o.officerDetailsNotKnown)
+  @Transform(({ value, obj }) => (obj.probationOfficerDetailsKnown === YesNo.YES ? value : undefined))
+  @ValidateIf(o => o.probationOfficerDetailsKnown === YesNo.YES)
   @IsNotEmpty({ message: `Enter the probation officer's full name` })
   officerFullName: string
 
   @Expose()
-  @ValidateIf(o => o.officerDetailsOrUnknown && !o.officerDetailsNotKnown)
+  @Transform(({ value, obj }) => (obj.probationOfficerDetailsKnown === YesNo.YES ? value : undefined))
+  @ValidateIf(o => o.probationOfficerDetailsKnown === YesNo.YES)
   @IsEmail({}, { message: 'Enter a valid email address' })
   @IsNotEmpty({ message: `Enter the probation officer's email address` })
   officerEmail: string
 
   @Expose()
-  @ValidateIf(o => o.officerDetailsOrUnknown && !o.officerDetailsNotKnown)
+  @Transform(({ value, obj }) => (obj.probationOfficerDetailsKnown === YesNo.YES ? value : undefined))
+  @ValidateIf(o => o.probationOfficerDetailsKnown === YesNo.YES)
   @IsOptional()
   @IsValidUkPhoneNumber({ message: 'Enter a valid UK phone number' })
   officerTelephone: string
@@ -144,7 +138,7 @@ export default class BookingDetailsHandler implements PageHandler {
 
     const {
       probationTeamCode,
-      officerDetailsNotKnown,
+      probationOfficerDetailsKnown,
       officerFullName,
       officerEmail,
       officerTelephone,
@@ -171,16 +165,17 @@ export default class BookingDetailsHandler implements PageHandler {
         prisonName: prisoner.prisonName,
       },
       probationTeamCode,
-      officerDetailsNotKnown,
-      officer: officerDetailsNotKnown
-        ? undefined
-        : {
-            fullName: officerFullName,
-            email: officerEmail,
-            telephone: officerTelephone
-              ? parsePhoneNumberWithError(officerTelephone, 'GB').formatNational()
-              : undefined,
-          },
+      probationOfficerDetailsKnown: probationOfficerDetailsKnown === YesNo.YES,
+      officer:
+        probationOfficerDetailsKnown === YesNo.YES
+          ? {
+              fullName: officerFullName,
+              email: officerEmail,
+              telephone: officerTelephone
+                ? parsePhoneNumberWithError(officerTelephone, 'GB').formatNational()
+                : undefined,
+            }
+          : undefined,
       meetingTypeCode,
       date: date.toISOString(),
       notesForStaff,

--- a/server/routes/journeys/bookAVideoLink/probation/journey.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/journey.ts
@@ -10,7 +10,7 @@ export type BookAProbationMeetingJourney = {
     prisonName: string
   }
   probationTeamCode?: string
-  officerDetailsNotKnown?: boolean
+  probationOfficerDetailsKnown?: boolean
   officer?: {
     fullName: string
     email: string

--- a/server/routes/journeys/bookAVideoLink/probation/middleware/initialiseJourney.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/middleware/initialiseJourney.ts
@@ -33,14 +33,15 @@ export default ({ videoLinkService, prisonerService }: Services): RequestHandler
         prisonName: prisoner.prisonName,
       },
       probationTeamCode: booking.probationTeamCode,
-      officerDetailsNotKnown: booking.additionalBookingDetails?.contactName === undefined,
-      officer: booking.additionalBookingDetails?.contactName
-        ? {
-            fullName: booking.additionalBookingDetails?.contactName,
-            email: booking.additionalBookingDetails?.contactEmail,
-            telephone: booking.additionalBookingDetails?.contactNumber,
-          }
-        : undefined,
+      probationOfficerDetailsKnown: booking.additionalBookingDetails?.contactName !== undefined,
+      officer:
+        booking.additionalBookingDetails?.contactName !== undefined
+          ? {
+              fullName: booking.additionalBookingDetails?.contactName,
+              email: booking.additionalBookingDetails?.contactEmail,
+              telephone: booking.additionalBookingDetails?.contactNumber,
+            }
+          : undefined,
       meetingTypeCode: booking.probationMeetingType,
       date: parseDateToISOString(mainAppointment.appointmentDate),
       duration: differenceInMinutes(parseTime(mainAppointment.endTime), parseTime(mainAppointment.startTime)),

--- a/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
@@ -53,68 +53,74 @@
                 {% endif %}
 
 
-                <div class="govuk-form-group {{ 'govuk-form-group--error' if validationErrors | findError("officerDetailsOrUnknown") }}">
+                <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Enter the probation officer's details</legend>
-                        <p id="officerDetailsOrUnknown" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span>{{ (validationErrors | findError("officerDetailsOrUnknown")).text }}</p>
-                        <p class="govuk-body">You can enter the details later if not yet known</p>
-                        {{ govukCheckboxes({
-                            idPrefix: "officerDetailsNotKnown",
-                            name: "officerDetailsNotKnown",
+                        {% set probationOfficerDetailsHtml %}
+                            {{ govukInput({
+                                id: "officerFullName",
+                                name: "officerFullName",
+                                label: {
+                                    text: "Full name"
+                                },
+                                errorMessage: validationErrors | findError('officerFullName'),
+                                formGroup: {
+                                    classes: 'govuk-!-margin-bottom-3'
+                                },
+                                classes: "govuk-!-width-one-half",
+                                value: formResponses.officerFullName or session.journey.bookAProbationMeeting.officer.fullName
+                            }) }}
+
+                            {{ govukInput({
+                                id: "officerEmail",
+                                name: "officerEmail",
+                                label: {
+                                    text: "Email address"
+                                },
+                                errorMessage: validationErrors | findError('officerEmail'),
+                                formGroup: {
+                                    classes: 'govuk-!-margin-bottom-3'
+                                },
+                                classes: "govuk-!-width-one-half",
+                                value: formResponses.officerEmail or session.journey.bookAProbationMeeting.officer.email
+                            }) }}
+
+                            {{ govukInput({
+                                id: "officerTelephone",
+                                name: "officerTelephone",
+                                label: {
+                                    text: "UK phone number (optional)"
+                                },
+                                errorMessage: validationErrors | findError('officerTelephone'),
+                                classes: "govuk-!-width-one-half",
+                                value: formResponses.officerTelephone or session.journey.bookAProbationMeeting.officer.telephone
+                            }) }}
+                        {% endset %}
+
+                        {{ govukRadios({
+                            idPrefix: "probationOfficerDetailsKnown",
+                            name: "probationOfficerDetailsKnown",
+                            errorMessage: validationErrors | findError('probationOfficerDetailsKnown'),
+                            fieldset: {
+                                legend: {
+                                    text: "Do you know the details of the probation officer?",
+                                    classes: "govuk-fieldset__legend--s"
+                                }
+                            },
                             items: [
                                 {
-                                    value: "true",
-                                    text: "Not yet known",
-                                    checked: formResponses.officerDetailsNotKnown or session.journey.bookAProbationMeeting.officerDetailsNotKnown
+                                    value: 'yes',
+                                    text: "Yes",
+                                    checked: formResponses.probationOfficerDetailsKnown == 'yes' or session.journey.bookAProbationMeeting.probationOfficerDetailsKnown === true,
+                                    conditional: {
+                                    html: probationOfficerDetailsHtml
+                                }
                                 },
                                 {
-                                    divider: "or"
+                                    value: 'no',
+                                    text: "No",
+                                    checked: formResponses.probationOfficerDetailsKnown == 'no' or (session.journey.bookAProbationMeeting.probationOfficerDetailsKnown === false and not formResponses)
                                 }
-                            ],
-                            errorMessage: validationErrors | findError("officerDetailsNotKnown"),
-                            formGroup: {
-                                classes: 'govuk-!-margin-bottom-3'
-                            },
-                            classes: "govuk-!-width-one-third"
-                        }) }}
-
-                        {{ govukInput({
-                            id: "officerFullName",
-                            name: "officerFullName",
-                            label: {
-                                text: "Full name"
-                            },
-                            errorMessage: validationErrors | findError('officerFullName'),
-                            formGroup: {
-                                classes: 'govuk-!-margin-bottom-3'
-                            },
-                            classes: "govuk-!-width-one-half",
-                            value: formResponses.officerFullName or session.journey.bookAProbationMeeting.officer.fullName
-                        }) }}
-
-                        {{ govukInput({
-                            id: "officerEmail",
-                            name: "officerEmail",
-                            label: {
-                                text: "Email address"
-                            },
-                            errorMessage: validationErrors | findError('officerEmail'),
-                            formGroup: {
-                                classes: 'govuk-!-margin-bottom-3'
-                            },
-                            classes: "govuk-!-width-one-half",
-                            value: formResponses.officerEmail or session.journey.bookAProbationMeeting.officer.email
-                        }) }}
-
-                        {{ govukInput({
-                            id: "officerTelephone",
-                            name: "officerTelephone",
-                            label: {
-                                text: "UK phone number (optional)"
-                            },
-                            errorMessage: validationErrors | findError('officerTelephone'),
-                            classes: "govuk-!-width-one-half",
-                            value: formResponses.officerTelephone or session.journey.bookAProbationMeeting.officer.telephone
+                            ]
                         }) }}
                     </fieldset>
                 </div>


### PR DESCRIPTION
Now using conditional radio instead of checkbox to determine if user knows what to enter for the probation officer details.

**BEFORE**

<img width="3122" height="2222" alt="screenshot-0" src="https://github.com/user-attachments/assets/bfcd0412-c2b0-4a45-b3a6-ce23208f5648" />

**AFTER**

<img width="3122" height="2222" alt="screenshot-1" src="https://github.com/user-attachments/assets/c60b30b6-0fa5-4920-9a57-bd84ac7a7514" />

<img width="3122" height="2222" alt="screenshot-3" src="https://github.com/user-attachments/assets/8f32895f-9a66-4c8a-bc8c-14ab87a7979d" />

<img width="3122" height="2222" alt="screenshot-2" src="https://github.com/user-attachments/assets/1e3b806e-f9a3-46af-b5e0-0ad9975f9201" />
