### PR TITLE
BAVL-1339 small fixes for the probation radio changes. Missed removal of old field from template and small styling tweak.

### DIFF
--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingAvailabilityHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingAvailabilityHandler.test.ts
@@ -41,12 +41,6 @@ const bookAProbationMeetingSession = {
     prisonName: 'Moorland',
     prisonerNumber: 'A1234AA',
   },
-  officerDetailsNotKnown: false,
-  officer: {
-    fullName: 'John Bing',
-    email: 'jbing@gmail.com',
-    telephone: '07892 398108',
-  },
   duration: 120,
   timePeriods: ['AM'],
 }

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/checkBookingHandler.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, journeyId, user } from '../../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../../services/auditService'
-import { existsByDataQa, existsByKey, getPageHeader } from '../../../../testutils/cheerio'
+import { existsByDataQa, existsByKey, getPageHeader, getValueByKey } from '../../../../testutils/cheerio'
 import ProbationTeamsService from '../../../../../services/probationTeamsService'
 import PrisonService from '../../../../../services/prisonService'
 import VideoLinkService from '../../../../../services/videoLinkService'
@@ -82,12 +82,18 @@ describe('Check Booking handler', () => {
   })
 
   describe('GET', () => {
-    it('should render the correct view page', () => {
+    it('should render the correct view page with officer details', () => {
       appSetup({
         bookAProbationMeeting: {
           prisoner: { prisonId: 'MDI' },
           date: '2024-06-12',
           startTime: '1970-01-01T16:00',
+          probationOfficerDetailsKnown: true,
+          officer: {
+            fullName: 'John Bing',
+            email: 'jbing@gmail.com',
+            telephone: '07892 398108',
+          },
         },
       })
 
@@ -108,6 +114,41 @@ describe('Check Booking handler', () => {
 
           expect(probationTeamsService.getUserPreferences).toHaveBeenCalledTimes(2)
           expect(referenceDataService.getProbationMeetingTypes).toHaveBeenCalledWith(user)
+          expect(getValueByKey($, 'Name of probation officer')).toEqual('John Bing')
+          expect(getValueByKey($, 'Email (probation officer)')).toEqual('jbing@gmail.com')
+          expect(getValueByKey($, 'Phone number (probation officer)')).toEqual('07892 398108')
+        })
+    })
+    it('should render the correct view page with out fficer details', () => {
+      appSetup({
+        bookAProbationMeeting: {
+          prisoner: { prisonId: 'MDI' },
+          date: '2024-06-12',
+          startTime: '1970-01-01T16:00',
+          probationOfficerDetailsKnown: false,
+        },
+      })
+
+      return request(app)
+        .get(`/probation/booking/create/${journeyId()}/A1234AA/video-link-booking/check-booking`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          const heading = getPageHeader($)
+
+          expect(heading).toEqual('Check and confirm your booking')
+          expect(existsByKey($, 'Notes for prison staff')).toBe(true)
+
+          expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_BOOKING_PAGE, {
+            who: user.username,
+            correlationId: expect.any(String),
+          })
+
+          expect(probationTeamsService.getUserPreferences).toHaveBeenCalledTimes(2)
+          expect(referenceDataService.getProbationMeetingTypes).toHaveBeenCalledWith(user)
+          expect(getValueByKey($, 'Name of probation officer')).toEqual('Not yet known')
+          expect(getValueByKey($, 'Email (probation officer)')).toEqual('Not yet known')
+          expect(getValueByKey($, 'Phone number (probation officer)')).toEqual('Not yet known')
         })
     })
 

--- a/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
@@ -52,77 +52,74 @@
                     }) }}
                 {% endif %}
 
-
                 <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        {% set probationOfficerDetailsHtml %}
-                            {{ govukInput({
-                                id: "officerFullName",
-                                name: "officerFullName",
-                                label: {
-                                    text: "Full name"
-                                },
-                                errorMessage: validationErrors | findError('officerFullName'),
-                                formGroup: {
-                                    classes: 'govuk-!-margin-bottom-3'
-                                },
-                                classes: "govuk-!-width-one-half",
-                                value: formResponses.officerFullName or session.journey.bookAProbationMeeting.officer.fullName
-                            }) }}
-
-                            {{ govukInput({
-                                id: "officerEmail",
-                                name: "officerEmail",
-                                label: {
-                                    text: "Email address"
-                                },
-                                errorMessage: validationErrors | findError('officerEmail'),
-                                formGroup: {
-                                    classes: 'govuk-!-margin-bottom-3'
-                                },
-                                classes: "govuk-!-width-one-half",
-                                value: formResponses.officerEmail or session.journey.bookAProbationMeeting.officer.email
-                            }) }}
-
-                            {{ govukInput({
-                                id: "officerTelephone",
-                                name: "officerTelephone",
-                                label: {
-                                    text: "UK phone number (optional)"
-                                },
-                                errorMessage: validationErrors | findError('officerTelephone'),
-                                classes: "govuk-!-width-one-half",
-                                value: formResponses.officerTelephone or session.journey.bookAProbationMeeting.officer.telephone
-                            }) }}
-                        {% endset %}
-
-                        {{ govukRadios({
-                            idPrefix: "probationOfficerDetailsKnown",
-                            name: "probationOfficerDetailsKnown",
-                            errorMessage: validationErrors | findError('probationOfficerDetailsKnown'),
-                            fieldset: {
-                                legend: {
-                                    text: "Do you know the details of the probation officer?",
-                                    classes: "govuk-fieldset__legend--s"
-                                }
+                    {% set probationOfficerDetailsHtml %}
+                        {{ govukInput({
+                            id: "officerFullName",
+                            name: "officerFullName",
+                            label: {
+                                text: "Full name"
                             },
-                            items: [
-                                {
-                                    value: 'yes',
-                                    text: "Yes",
-                                    checked: formResponses.probationOfficerDetailsKnown == 'yes' or session.journey.bookAProbationMeeting.probationOfficerDetailsKnown === true,
-                                    conditional: {
-                                    html: probationOfficerDetailsHtml
-                                }
-                                },
-                                {
-                                    value: 'no',
-                                    text: "No",
-                                    checked: formResponses.probationOfficerDetailsKnown == 'no' or (session.journey.bookAProbationMeeting.probationOfficerDetailsKnown === false and not formResponses)
-                                }
-                            ]
+                            errorMessage: validationErrors | findError('officerFullName'),
+                            formGroup: {
+                                classes: 'govuk-!-margin-bottom-3'
+                            },
+                            classes: "govuk-!-width-one-half",
+                            value: formResponses.officerFullName or session.journey.bookAProbationMeeting.officer.fullName
                         }) }}
-                    </fieldset>
+
+                        {{ govukInput({
+                            id: "officerEmail",
+                            name: "officerEmail",
+                            label: {
+                                text: "Email address"
+                            },
+                            errorMessage: validationErrors | findError('officerEmail'),
+                            formGroup: {
+                                classes: 'govuk-!-margin-bottom-3'
+                            },
+                            classes: "govuk-!-width-one-half",
+                            value: formResponses.officerEmail or session.journey.bookAProbationMeeting.officer.email
+                        }) }}
+
+                        {{ govukInput({
+                            id: "officerTelephone",
+                            name: "officerTelephone",
+                            label: {
+                                text: "UK phone number (optional)"
+                            },
+                            errorMessage: validationErrors | findError('officerTelephone'),
+                            classes: "govuk-!-width-one-half",
+                            value: formResponses.officerTelephone or session.journey.bookAProbationMeeting.officer.telephone
+                        }) }}
+                    {% endset %}
+
+                    {{ govukRadios({
+                        idPrefix: "probationOfficerDetailsKnown",
+                        name: "probationOfficerDetailsKnown",
+                        errorMessage: validationErrors | findError('probationOfficerDetailsKnown'),
+                        fieldset: {
+                            legend: {
+                                text: "Do you know the details of the probation officer?",
+                                classes: "govuk-fieldset__legend--s"
+                            }
+                        },
+                        items: [
+                            {
+                                value: 'yes',
+                                text: "Yes",
+                                checked: formResponses.probationOfficerDetailsKnown == 'yes' or session.journey.bookAProbationMeeting.probationOfficerDetailsKnown === true,
+                                conditional: {
+                                html: probationOfficerDetailsHtml
+                            }
+                            },
+                            {
+                                value: 'no',
+                                text: "No",
+                                checked: formResponses.probationOfficerDetailsKnown == 'no' or (session.journey.bookAProbationMeeting.probationOfficerDetailsKnown === false and not formResponses)
+                            }
+                        ]
+                    }) }}
                 </div>
 
                 {% set items = [] %}

--- a/server/views/pages/bookAVideoLink/probation/checkBooking.njk
+++ b/server/views/pages/bookAVideoLink/probation/checkBooking.njk
@@ -151,7 +151,7 @@
                             text: "Phone number (probation officer)"
                         },
                         value: {
-                            text: session.journey.bookAProbationMeeting.officer.telephone or ("Not yet known" if session.journey.bookAProbationMeeting.officerDetailsNotKnown else "None entered")
+                            text: session.journey.bookAProbationMeeting.officer.telephone or "Not yet known"
                         },
                         actions: {
                             items: [


### PR DESCRIPTION
Fixes a couple of issues spotted with old field reference still in a template and a style change, one too many fieldset tags.