### PR TITLE
BAVL-1343 security patch docker file fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
- Build args available to all stages
-ARG BUILD_NUMBER
-ARG GIT_REF
-ARG GIT_BRANCH
-
-# Stage: build assets
-FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS build
+# Stage: base image
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS base
 
 ARG BUILD_NUMBER
 ARG GIT_REF
@@ -15,23 +10,29 @@ RUN test -n "$BUILD_NUMBER" || (echo "BUILD_NUMBER not set" && false)
 RUN test -n "$GIT_REF" || (echo "GIT_REF not set" && false)
 RUN test -n "$GIT_BRANCH" || (echo "GIT_BRANCH not set" && false)
 
-WORKDIR /app
+# Define env variables for runtime health / info
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+ENV GIT_REF=${GIT_REF}
+ENV GIT_BRANCH=${GIT_BRANCH}
+
+# Stage: build assets
+FROM base AS build
+
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
 COPY package*.json .allowed-scripts.mjs .npmrc ./
-RUN NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false npm run setup
+RUN npm run setup
 ENV NODE_ENV='production'
 
 COPY . .
 RUN npm run build
 
-RUN npm prune --no-audit --no-fund --omit=dev
+RUN npm prune --no-audit --omit=dev
 
 # Stage: copy production assets and dependencies
-FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine-runtime
-
-ARG BUILD_NUMBER
-ARG GIT_REF
-ARG GIT_BRANCH
+FROM base
 
 COPY --from=build --chown=appuser:appgroup \
         /app/package.json \
@@ -45,10 +46,7 @@ COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
 EXPOSE 3000
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-ENV GIT_REF=${GIT_REF}
-ENV GIT_BRANCH=${GIT_BRANCH}
 ENV NODE_ENV='production'
 USER 2000
 
-CMD [ "node", "dist/server.js" ]
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Reverts the dockerfile change to all but one line to keep `npm run setup` happy.  Will address larger changes in a separate ticket.