### PR TITLE
BAVL-1323 this change updates the content for all staff notes hint text to be SAR compliant.  This change applies to court and probation.

### DIFF
--- a/server/routes/journeys/bookAVideoLink/court/handlers/bookingDetailsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/bookingDetailsHandler.test.ts
@@ -4,7 +4,7 @@ import * as cheerio from 'cheerio'
 import { startOfToday, startOfTomorrow, startOfYesterday } from 'date-fns'
 import { appWithAllRoutes, journeyId, user } from '../../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../../services/auditService'
-import { existsByLabel, getPageHeader } from '../../../../testutils/cheerio'
+import { existsByLabel, getByDataQa, getPageHeader } from '../../../../testutils/cheerio'
 import CourtsService from '../../../../../services/courtsService'
 import PrisonService from '../../../../../services/prisonService'
 import PrisonerService from '../../../../../services/prisonerService'
@@ -110,6 +110,9 @@ describe('Booking details handler', () => {
           expect(existsByLabel($, 'Select the court the hearing is for')).toBe(true)
           expect(existsByLabel($, 'Select the court hearing type')).toBe(true)
           expect(existsByLabel($, 'Notes for prison staff (optional)')).toBe(true)
+          expect(getByDataQa($, 'notes-for-staff-hint-text').text().trim()).toEqual(
+            "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details.The information in this text box could potentially be shared in accordance with the Data Protection Act 2018.",
+          )
         })
     })
 

--- a/server/routes/journeys/bookAVideoLink/court/handlers/commentsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/court/handlers/commentsHandler.test.ts
@@ -56,6 +56,9 @@ describe('Comments handler', () => {
             who: user.username,
             correlationId: expect.any(String),
           })
+          expect(getByDataQa($, 'notes-for-staff-hint-text').text().trim()).toEqual(
+            "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details.The information in this text box could potentially be shared in accordance with the Data Protection Act 2018.",
+          )
         })
     })
   })

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/bookingDetailsHandler.test.ts
@@ -4,7 +4,7 @@ import * as cheerio from 'cheerio'
 import { startOfTomorrow, startOfYesterday } from 'date-fns'
 import { appWithAllRoutes, journeyId, user } from '../../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../../services/auditService'
-import { dropdownOptions, existsByLabel, getPageHeader, radioOptions } from '../../../../testutils/cheerio'
+import { dropdownOptions, existsByLabel, getByDataQa, getPageHeader, radioOptions } from '../../../../testutils/cheerio'
 import ProbationTeamsService from '../../../../../services/probationTeamsService'
 import PrisonerService from '../../../../../services/prisonerService'
 import { expectErrorMessages, expectNoErrorMessages } from '../../../../testutils/expectErrorMessage'
@@ -124,6 +124,9 @@ describe('Booking details handler', () => {
 
           expect(heading).toEqual('Enter probation video link booking details for Joe Smith')
           expect(existsByLabel($, 'Notes for prison staff (optional)')).toBe(true)
+          expect(getByDataQa($, 'notes-for-staff-hint-text').text().trim()).toEqual(
+            'This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required.The information in this text box could potentially be shared in accordance with the Data Protection Act 2018.',
+          )
 
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.BOOKING_DETAILS_PAGE, {
             who: user.username,

--- a/server/routes/journeys/bookAVideoLink/probation/handlers/commentsHandler.test.ts
+++ b/server/routes/journeys/bookAVideoLink/probation/handlers/commentsHandler.test.ts
@@ -61,6 +61,9 @@ describe('Comments handler', () => {
 
           expect(heading).toEqual('Change notes on this booking')
           expect(cancelLink).toEqual(`/probation/view-booking/1001`)
+          expect(getByDataQa($, 'notes-for-staff-hint-text').text().trim()).toEqual(
+            'This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required.The information in this text box could potentially be shared in accordance with the Data Protection Act 2018.',
+          )
 
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.COMMENTS_PAGE, {
             who: user.username,

--- a/server/views/pages/bookAVideoLink/court/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/court/bookingDetails.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "partials/notesForStaff.njk" import notesForStaff %}
 
 {% set mode = session.req.routeContext.mode %}
 {% set prisonerName = ((prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase) %}
@@ -321,21 +321,7 @@
                     ]
                 }) }}
 
-                {{ govukCharacterCount({
-                    name: "notesForStaff",
-                    id: "notesForStaff",
-                    maxlength: 400,
-                    label: {
-                        text: "Notes for prison staff (optional)",
-                        classes: 'govuk-fieldset__legend--s'
-                    },
-                    hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
-                    formGroup: {
-                        classes: 'govuk-!-width-two-thirds'
-                    },
-                    errorMessage: validationErrors | findError('notesForStaff'),
-                    value: formResponses.notesForStaff or session.journey.bookACourtHearing.notesForStaff
-                }) }}
+                {{ notesForStaff("This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details.", formResponses.notesForStaff, session.journey.bookACourtHearing.notesForStaff) }}
 
                 {{ govukButton({
                     text: "Continue",

--- a/server/views/pages/bookAVideoLink/court/notesForStaff.njk
+++ b/server/views/pages/bookAVideoLink/court/notesForStaff.njk
@@ -1,7 +1,7 @@
 {% extends "partials/layout.njk" %}
 
-{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "partials/notesForStaff.njk" import notesForStaff %}
 
 {% set pageTitle = "Change notes on this booking" if session.journey.bookACourtHearing.notesForStaff else "Add notes on this booking" %}
 
@@ -17,18 +17,7 @@
             <form method="POST" action='check-booking' data-module="form-spinner" data-loading-text="Updating notes">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-                {{ govukCharacterCount({
-                    name: "notesForStaff",
-                    id: "notesForStaff",
-                    maxlength: 400,
-                    errorMessage: validationErrors | findError("notesForStaff"),
-                    label: {
-                        text: "Notes for prison staff (optional)",
-                        classes: 'govuk-fieldset__legend--s'
-                    },
-                    hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
-                    value: formResponses.notesForStaff or session.journey.bookACourtHearing.notesForStaff
-                }) }}
+                {{ notesForStaff("This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details.", formResponses.notesForStaff, session.journey.bookACourtHearing.notesForStaff) }}
 
                 {{ govukButton({
                     text: "Continue",

--- a/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
+++ b/server/views/pages/bookAVideoLink/probation/bookingDetails.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "partials/notesForStaff.njk" import notesForStaff %}
 
 {% set mode = session.req.routeContext.mode %}
 {% set pageTitle = ("Change" if mode == 'amend' else "Enter") + ' probation video link booking details' %}
@@ -277,21 +277,7 @@
                     }) }}
                 {% endif %}
 
-                {{ govukCharacterCount({
-                    name: "notesForStaff",
-                    id: "notesForStaff",
-                    maxlength: 400,
-                    label: {
-                        text: "Notes for prison staff (optional)",
-                        classes: 'govuk-fieldset__legend--s'
-                    },
-                    hint: { text: "This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required." },
-                    formGroup: {
-                        classes: 'govuk-!-width-two-thirds'
-                    },
-                    errorMessage: validationErrors | findError('notesForStaff'),
-                    value: formResponses.notesForStaff or session.journey.bookAProbationMeeting.notesForStaff
-                }) }}
+                {{ notesForStaff('This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required.', formResponses.notesForStaff, session.journey.bookAProbationMeeting.notesForStaff) }}
 
                 {{ govukButton({
                     text: "Continue",

--- a/server/views/pages/bookAVideoLink/probation/notesForStaff.njk
+++ b/server/views/pages/bookAVideoLink/probation/notesForStaff.njk
@@ -1,7 +1,7 @@
 {% extends "partials/layout.njk" %}
 
-{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "partials/notesForStaff.njk" import notesForStaff %}
 
 {% set pageTitle = "Change notes on this booking" if session.journey.bookAProbationMeeting.notesForStaff else "Add notes to this booking" %}
 
@@ -17,18 +17,7 @@
             <form method="POST" action='check-booking' data-module="form-spinner" data-loading-text="Updating notes">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-                {{ govukCharacterCount({
-                    name: "notesForStaff",
-                    id: "notesForStaff",
-                    maxlength: 400,
-                    errorMessage: validationErrors | findError("notesForStaff"),
-                    label: {
-                        text: "Notes for prison staff (optional)",
-                        classes: 'govuk-fieldset__legend--s'
-                    },
-                    hint: { text: "This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required." },
-                    value: formResponses.notesForStaff or session.journey.bookAProbationMeeting.notesForStaff
-                }) }}
+                {{ notesForStaff('This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required.', formResponses.notesForStaff, session.journey.bookAProbationMeeting.notesForStaff) }}
 
                 {{ govukButton({
                     text: "Continue",

--- a/server/views/partials/notesForStaff.njk
+++ b/server/views/partials/notesForStaff.njk
@@ -1,0 +1,22 @@
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+
+{% macro notesForStaff(hintText, formFieldNotesForStaff, sessionFieldNotesForStaff) %}
+    {{ govukCharacterCount({
+        name: "notesForStaff",
+        id: "notesForStaff",
+        maxlength: 400,
+        label: {
+            text: "Notes for prison staff (optional)",
+            classes: 'govuk-fieldset__legend--s'
+        },
+        hint: {
+            html: '<div>' + hintText + '</div><br><div>The information in this text box could potentially be shared in accordance with the Data Protection Act 2018.</div>',
+            attributes: { 'data-qa': 'notes-for-staff-hint-text' }
+        },
+        formGroup: {
+            classes: 'govuk-!-width-two-thirds'
+        },
+        errorMessage: validationErrors | findError('notesForStaff'),
+        value: formFieldNotesForStaff or sessionFieldNotesForStaff
+    }) }}
+{% endmacro %}


### PR DESCRIPTION
The ticket number this is under was really for court only, there is a separate ticket for the same change for probation.

However the change has moved staff notes into a reusable macro which meant it was a simple change to do both court and probation at the same time.

**COURT:**

<img width="4064" height="4702" alt="court-create" src="https://github.com/user-attachments/assets/f5fb65d9-0e9f-43c2-8a02-8d13c44c815a" />

<img width="4064" height="2162" alt="court-amend" src="https://github.com/user-attachments/assets/7dac7c1e-108c-42aa-89b0-ca6d328d82f0" />

**PROBATION:**

<img width="4064" height="4090" alt="probation-create" src="https://github.com/user-attachments/assets/f5832632-1e9e-4492-bc88-83a2cb495dc9" />

<img width="4064" height="2162" alt="probation-amend" src="https://github.com/user-attachments/assets/68c55ee8-1950-4fc0-ab6a-228291148b8b" />
