### PR TITLE
BAVL-1345 fix issue whereby time periods were not being sent on call to the BVLS API.

### DIFF
--- a/server/services/probationBookingService.test.ts
+++ b/server/services/probationBookingService.test.ts
@@ -58,7 +58,7 @@ describe('Probation booking service', () => {
   })
 
   describe('getAvailableLocations', () => {
-    it('should correctly fetch the list of available locations', async () => {
+    it('should correctly fetch the list of available locations with time periods', async () => {
       const journey = {
         prisoner: {
           prisonId: 'MDI',
@@ -85,6 +85,39 @@ describe('Probation booking service', () => {
           probationTeamCode: 'AGENCY_CODE',
           date: '2022-03-20',
           bookingDuration: 120,
+          timePeriods: ['AM'],
+        },
+        user,
+      )
+    })
+
+    it('should correctly fetch the list of available locations with no time periods', async () => {
+      const journey = {
+        prisoner: {
+          prisonId: 'MDI',
+          prisonerNumber: 'ABC123',
+          prisonName: 'Moorland',
+          firstName: 'Joe',
+          lastName: 'Bloggs',
+        },
+        date: '2022-03-20T00:00:00Z',
+        locationCode: 'LOCATION_CODE',
+        startTime: '1970-01-01T13:30:00Z',
+        endTime: '1970-01-01T14:30:00Z',
+        probationTeamCode: 'AGENCY_CODE',
+        duration: 120,
+      } as BookAProbationMeetingJourney
+
+      await probationBookingService.getAvailableLocations(journey, user)
+
+      expect(bookAVideoLinkClient.fetchAvailableLocations).toHaveBeenCalledWith(
+        {
+          prisonCode: 'MDI',
+          bookingType: 'PROBATION',
+          probationTeamCode: 'AGENCY_CODE',
+          date: '2022-03-20',
+          bookingDuration: 120,
+          timePeriods: [],
         },
         user,
       )

--- a/server/services/probationBookingService.ts
+++ b/server/services/probationBookingService.ts
@@ -27,6 +27,7 @@ export default class ProbationBookingService {
       date: formatDate(journey.date, 'yyyy-MM-dd'),
       bookingDuration: journey.duration,
       vlbIdToExclude: journey.bookingId,
+      timePeriods: journey.timePeriods || [],
     } as TimeSlotAvailabilityRequest
 
     return this.bookAVideoLinkApiClient.fetchAvailableLocations(request, user)


### PR DESCRIPTION
I was a little surprised to find this one.  Came out in the testing wash.