### PR TITLE
BAVL-1435 somewhere down the line case of a field had change in a template but not in the code so court codes and probation codes on room admin where being ignored.

### DIFF
--- a/server/routes/journeys/admin/handlers/shared/roomFunctions.ts
+++ b/server/routes/journeys/admin/handlers/shared/roomFunctions.ts
@@ -161,7 +161,7 @@ export const chooseAllowedParties = (
   courtCodes: string[],
   probationTeamCodes: string[],
 ): string[] => {
-  switch (permission) {
+  switch (permission.trim().toUpperCase()) {
     case 'COURT':
       return courtCodes
     case 'PROBATION':


### PR DESCRIPTION
This fixes an issue whereby the submitted permission from the template did not match that of function expecting it.  The case was different, lowercase versus uppercase equality checking.

The permission is being submitted in lowercase e.g. 'court' or 'probation' but the function was expecting uppercase only.

The area around room admin for multiple courts and/or probation teams is lacking in the integration tests.  This will be addressed as a separate action.