### PR TITLE
BAVL-1435 improve integration test coverage for room decoration to include test for adding multiple courts.

### DIFF
--- a/assets/js/skip-link.js
+++ b/assets/js/skip-link.js
@@ -1,6 +1,4 @@
 function overrideSkipLink() {
-  console.log('Initialising skip link override...')
-
   const skipLink = document.querySelector('.govuk-skip-link')
   const mainContent = document.getElementById('main-content')
 

--- a/integration_tests/pages/administration/editRoom.ts
+++ b/integration_tests/pages/administration/editRoom.ts
@@ -53,6 +53,11 @@ export default class EditRoomPage extends AbstractPage {
   selectRoomStatus = (status: 'active' | 'inactive' | 'temporarily_blocked') =>
     this.page.locator(`input[name="roomStatus"][value="${status}"]`).check()
 
+  selectCourt = (court: string, index: number) =>
+    this.page.locator('select[name="courtCodes"]').nth(index).selectOption(court)
+
+  addAnotherCourt = () => this.page.getByRole('button', { name: 'Add another court' }).click()
+
   assertRoomChangesSaved = () =>
     expect(this.page.locator('.moj-alert__content')).toContainText('Room changes have been saved')
 

--- a/integration_tests/specs/administration.spec.ts
+++ b/integration_tests/specs/administration.spec.ts
@@ -128,7 +128,7 @@ test.describe('Administration', () => {
             attributeId: 56,
             locationStatus: 'INACTIVE',
             locationUsage: 'COURT',
-            allowedParties: ['ABERCV'],
+            allowedParties: [],
             prisonVideoUrl: null,
             notes: null,
             schedule: [
@@ -167,6 +167,9 @@ test.describe('Administration', () => {
       await editRoomPage.assertRoomLink('')
       await editRoomPage.assertSelectedRoomPermission('court')
       await editRoomPage.selectRoomStatus('active')
+      await editRoomPage.selectCourt('DRBYMC', 0)
+      await editRoomPage.addAnotherCourt()
+      await editRoomPage.selectCourt('HERFMC', 1)
       await editRoomPage.enterRoomLink('https://prison-room-link')
       await editRoomPage.enterComments('This is a comment')
 
@@ -181,7 +184,7 @@ test.describe('Administration', () => {
           attributeId: 56,
           locationStatus: 'ACTIVE',
           locationUsage: 'COURT',
-          allowedParties: ['ABERCV'],
+          allowedParties: ['DRBYMC', 'HERFMC'],
           prisonVideoUrl: 'https://prison-room-link',
           notes: 'This is a comment',
           schedule: [


### PR DESCRIPTION
Retrospectively adding integration test coverage for adding multiple courts during room decoration.  The makes sure we will know if the `Add another court/probation` functionality breaks in future.

This was fixed in this PR [here](https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/pull/378).